### PR TITLE
refactor: modernize standard library idioms

### DIFF
--- a/clientgenv2/source_generator.go
+++ b/clientgenv2/source_generator.go
@@ -3,7 +3,7 @@ package clientgenv2
 import (
 	"fmt"
 	"go/types"
-	"sort"
+	"slices"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -86,8 +86,8 @@ func (rs ResponseFieldList) MapByName() map[string]*ResponseField {
 }
 
 func (rs ResponseFieldList) SortByName() ResponseFieldList {
-	sort.Slice(rs, func(i, j int) bool {
-		return rs[i].Name < rs[j].Name
+	slices.SortFunc(rs, func(a, b *ResponseField) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	return rs

--- a/clientgenv2/template.go
+++ b/clientgenv2/template.go
@@ -65,9 +65,7 @@ func (g *GenGettersGenerator) GenFunc() func(name string, p types.Type) string {
 
 		var buf bytes.Buffer
 
-		for i := range it.NumFields() {
-			field := it.Field(i)
-
+		for field := range it.Fields() {
 			returns := g.returnTypeName(field.Type(), false)
 
 			buf.WriteString("func (t *" + name + ") Get" + field.Name() + "() " + returns + "{\n")
@@ -143,8 +141,8 @@ func (g *GenGettersGenerator) writeConversionGetter(buf *bytes.Buffer, ownerName
 // writeStructLiteral writes field assignments for a struct literal, delegating
 // each field to writeFieldAssignment.
 func (g *GenGettersGenerator) writeStructLiteral(buf *bytes.Buffer, targetStruct *types.Struct, sourceExpr string) {
-	for i := range targetStruct.NumFields() {
-		g.writeFieldAssignment(buf, targetStruct.Field(i), sourceExpr)
+	for field := range targetStruct.Fields() {
+		g.writeFieldAssignment(buf, field, sourceExpr)
 	}
 }
 

--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -424,8 +424,7 @@ func (c *Client) parseResponse(body []byte, httpCode int, result any) error {
 	// some servers return a graphql error with a non OK http code, try anyway to parse the body
 	err := c.unmarshal(body, result)
 	if err != nil {
-		var gqlErr *GqlErrorList
-		if errors.As(err, &gqlErr) {
+		if gqlErr, ok := errors.AsType[*GqlErrorList](err); ok {
 			errResponse.GqlErrors = &gqlErr.Errors
 		} else if !isOKCode {
 			return err

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
+	"strings"
 	"syscall"
 
 	"github.com/99designs/gqlgen/api"
@@ -16,6 +17,8 @@ import (
 	"github.com/gqlgo/gqlgenc/config"
 	"github.com/gqlgo/gqlgenc/parsequery"
 	"github.com/gqlgo/gqlgenc/querydocument"
+
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 func mutateHook(cfg *config.Config, usedTypes map[string]bool) func(b *modelgen.ModelBuild) *modelgen.ModelBuild {
@@ -90,7 +93,7 @@ func Generate(ctx context.Context, cfg *config.Config) error {
 
 	// sort Implements to ensure a deterministic output
 	for _, v := range cfg.GQLConfig.Schema.Implements {
-		sort.Slice(v, func(i, j int) bool { return v[i].Name < v[j].Name })
+		slices.SortFunc(v, func(a, b *ast.Definition) int { return strings.Compare(a.Name, b.Name) })
 	}
 
 	querySources, err := parsequery.LoadQuerySources(cfg.Query)

--- a/introspection/parse.go
+++ b/introspection/parse.go
@@ -43,8 +43,8 @@ func (p parser) parseIntrospectionQuery(query Query) *ast.SchemaDocument {
 
 	p.deprecatedDirectiveDefinition = doc.Directives.ForName("deprecated")
 
-	for _, typeVale := range p.typeMap {
-		doc.Definitions = append(doc.Definitions, p.parseTypeSystemDefinition(typeVale))
+	for _, typeValue := range p.typeMap {
+		doc.Definitions = append(doc.Definitions, p.parseTypeSystemDefinition(typeValue))
 	}
 
 	return &doc
@@ -110,9 +110,9 @@ func (p parser) parseDirectiveDefinition(directiveValue *DirectiveType) *ast.Dir
 	}
 }
 
-func (p parser) parseObjectFields(typeVale *FullType) ast.FieldList {
-	fieldList := make(ast.FieldList, 0, len(typeVale.Fields))
-	for _, field := range typeVale.Fields {
+func (p parser) parseObjectFields(typeValue *FullType) ast.FieldList {
+	fieldList := make(ast.FieldList, 0, len(typeValue.Fields))
+	for _, field := range typeValue.Fields {
 		typ := p.getType(&field.Type)
 
 		args := make(ast.ArgumentDefinitionList, 0, len(field.Args))
@@ -135,9 +135,9 @@ func (p parser) parseObjectFields(typeVale *FullType) ast.FieldList {
 	return fieldList
 }
 
-func (p parser) parseInputObjectFields(typeVale *FullType) ast.FieldList {
-	fieldList := make(ast.FieldList, 0, len(typeVale.InputFields))
-	for _, field := range typeVale.InputFields {
+func (p parser) parseInputObjectFields(typeValue *FullType) ast.FieldList {
+	fieldList := make(ast.FieldList, 0, len(typeValue.InputFields))
+	for _, field := range typeValue.InputFields {
 		typ := p.getType(&field.Type)
 		fieldDefinition := &ast.FieldDefinition{
 			Description: pointerString(field.Description),
@@ -151,16 +151,16 @@ func (p parser) parseInputObjectFields(typeVale *FullType) ast.FieldList {
 	return fieldList
 }
 
-func (p parser) parseObjectTypeDefinition(typeVale *FullType) *ast.Definition {
-	fieldList := p.parseObjectFields(typeVale)
+func (p parser) parseObjectTypeDefinition(typeValue *FullType) *ast.Definition {
+	fieldList := p.parseObjectFields(typeValue)
 
-	interfaces := make([]string, 0, len(typeVale.Interfaces))
-	for _, intf := range typeVale.Interfaces {
+	interfaces := make([]string, 0, len(typeValue.Interfaces))
+	for _, intf := range typeValue.Interfaces {
 		interfaces = append(interfaces, pointerString(intf.Name))
 	}
 
-	enums := make(ast.EnumValueList, 0, len(typeVale.EnumValues))
-	for _, enum := range typeVale.EnumValues {
+	enums := make(ast.EnumValueList, 0, len(typeValue.EnumValues))
+	for _, enum := range typeValue.EnumValues {
 		enumValue := &ast.EnumValueDefinition{
 			Description: pointerString(enum.Description),
 			Name:        enum.Name,
@@ -171,28 +171,28 @@ func (p parser) parseObjectTypeDefinition(typeVale *FullType) *ast.Definition {
 
 	return &ast.Definition{
 		Kind:        ast.Object,
-		Description: pointerString(typeVale.Description),
-		Name:        pointerString(typeVale.Name),
+		Description: pointerString(typeValue.Description),
+		Name:        pointerString(typeValue.Name),
 		Interfaces:  interfaces,
 		Fields:      fieldList,
 		EnumValues:  enums,
 		Position:    p.sharedPosition,
-		BuiltIn:     builtInObject(typeVale),
+		BuiltIn:     builtInObject(typeValue),
 	}
 }
 
-func (p parser) parseInterfaceTypeDefinition(typeVale *FullType) *ast.Definition {
-	fieldList := p.parseObjectFields(typeVale)
+func (p parser) parseInterfaceTypeDefinition(typeValue *FullType) *ast.Definition {
+	fieldList := p.parseObjectFields(typeValue)
 
-	interfaces := make([]string, 0, len(typeVale.Interfaces))
-	for _, intf := range typeVale.Interfaces {
+	interfaces := make([]string, 0, len(typeValue.Interfaces))
+	for _, intf := range typeValue.Interfaces {
 		interfaces = append(interfaces, pointerString(intf.Name))
 	}
 
 	return &ast.Definition{
 		Kind:        ast.Interface,
-		Description: pointerString(typeVale.Description),
-		Name:        pointerString(typeVale.Name),
+		Description: pointerString(typeValue.Description),
+		Name:        pointerString(typeValue.Name),
 		Interfaces:  interfaces,
 		Fields:      fieldList,
 		Position:    p.sharedPosition,
@@ -200,18 +200,18 @@ func (p parser) parseInterfaceTypeDefinition(typeVale *FullType) *ast.Definition
 	}
 }
 
-func (p parser) parseInputObjectTypeDefinition(typeVale *FullType) *ast.Definition {
-	fieldList := p.parseInputObjectFields(typeVale)
+func (p parser) parseInputObjectTypeDefinition(typeValue *FullType) *ast.Definition {
+	fieldList := p.parseInputObjectFields(typeValue)
 
-	interfaces := make([]string, 0, len(typeVale.Interfaces))
-	for _, intf := range typeVale.Interfaces {
+	interfaces := make([]string, 0, len(typeValue.Interfaces))
+	for _, intf := range typeValue.Interfaces {
 		interfaces = append(interfaces, pointerString(intf.Name))
 	}
 
 	return &ast.Definition{
 		Kind:        ast.InputObject,
-		Description: pointerString(typeVale.Description),
-		Name:        pointerString(typeVale.Name),
+		Description: pointerString(typeValue.Description),
+		Name:        pointerString(typeValue.Name),
 		Interfaces:  interfaces,
 		Fields:      fieldList,
 		Position:    p.sharedPosition,
@@ -219,25 +219,25 @@ func (p parser) parseInputObjectTypeDefinition(typeVale *FullType) *ast.Definiti
 	}
 }
 
-func (p parser) parseUnionTypeDefinition(typeVale *FullType) *ast.Definition {
-	unions := make([]string, 0, len(typeVale.PossibleTypes))
-	for _, unionValue := range typeVale.PossibleTypes {
+func (p parser) parseUnionTypeDefinition(typeValue *FullType) *ast.Definition {
+	unions := make([]string, 0, len(typeValue.PossibleTypes))
+	for _, unionValue := range typeValue.PossibleTypes {
 		unions = append(unions, *unionValue.Name)
 	}
 
 	return &ast.Definition{
 		Kind:        ast.Union,
-		Description: pointerString(typeVale.Description),
-		Name:        pointerString(typeVale.Name),
+		Description: pointerString(typeValue.Description),
+		Name:        pointerString(typeValue.Name),
 		Types:       unions,
 		Position:    p.sharedPosition,
 		BuiltIn:     false,
 	}
 }
 
-func (p parser) parseEnumTypeDefinition(typeVale *FullType) *ast.Definition {
-	enums := make(ast.EnumValueList, 0, len(typeVale.EnumValues))
-	for _, enum := range typeVale.EnumValues {
+func (p parser) parseEnumTypeDefinition(typeValue *FullType) *ast.Definition {
+	enums := make(ast.EnumValueList, 0, len(typeValue.EnumValues))
+	for _, enum := range typeValue.EnumValues {
 		enumValue := &ast.EnumValueDefinition{
 			Description: pointerString(enum.Description),
 			Name:        enum.Name,
@@ -248,43 +248,43 @@ func (p parser) parseEnumTypeDefinition(typeVale *FullType) *ast.Definition {
 
 	return &ast.Definition{
 		Kind:        ast.Enum,
-		Description: pointerString(typeVale.Description),
-		Name:        pointerString(typeVale.Name),
+		Description: pointerString(typeValue.Description),
+		Name:        pointerString(typeValue.Name),
 		EnumValues:  enums,
 		Position:    p.sharedPosition,
-		BuiltIn:     builtInEnum(typeVale),
+		BuiltIn:     builtInEnum(typeValue),
 	}
 }
 
-func (p parser) parseScalarTypeExtension(typeVale *FullType) *ast.Definition {
+func (p parser) parseScalarTypeExtension(typeValue *FullType) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
-		Description: pointerString(typeVale.Description),
-		Name:        pointerString(typeVale.Name),
+		Description: pointerString(typeValue.Description),
+		Name:        pointerString(typeValue.Name),
 		Position:    p.sharedPosition,
-		BuiltIn:     builtInScalar(typeVale),
+		BuiltIn:     builtInScalar(typeValue),
 	}
 }
 
-func (p parser) parseTypeSystemDefinition(typeVale *FullType) *ast.Definition {
-	switch typeVale.Kind {
+func (p parser) parseTypeSystemDefinition(typeValue *FullType) *ast.Definition {
+	switch typeValue.Kind {
 	case TypeKindScalar:
-		return p.parseScalarTypeExtension(typeVale)
+		return p.parseScalarTypeExtension(typeValue)
 	case TypeKindInterface:
-		return p.parseInterfaceTypeDefinition(typeVale)
+		return p.parseInterfaceTypeDefinition(typeValue)
 	case TypeKindEnum:
-		return p.parseEnumTypeDefinition(typeVale)
+		return p.parseEnumTypeDefinition(typeValue)
 	case TypeKindUnion:
-		return p.parseUnionTypeDefinition(typeVale)
+		return p.parseUnionTypeDefinition(typeValue)
 	case TypeKindObject:
-		return p.parseObjectTypeDefinition(typeVale)
+		return p.parseObjectTypeDefinition(typeValue)
 	case TypeKindInputObject:
-		return p.parseInputObjectTypeDefinition(typeVale)
+		return p.parseInputObjectTypeDefinition(typeValue)
 	case TypeKindList, TypeKindNonNull:
-		panic(fmt.Sprintf("not match Kind: %s", typeVale.Kind))
+		panic(fmt.Sprintf("not match Kind: %s", typeValue.Kind))
 	}
 
-	panic(fmt.Sprintf("not match Kind: %s", typeVale.Kind))
+	panic(fmt.Sprintf("not match Kind: %s", typeValue.Kind))
 }
 
 func (p parser) buildInputValue(input *InputValue) *ast.ArgumentDefinition {


### PR DESCRIPTION
## Summary

Modernize several standard library idioms across the codebase. There is no behavior change.

- `clientv2`: replace the two-line `errors.As` pattern with the generic `errors.AsType` helper
- `clientgenv2`: replace `sort.Slice` with `slices.SortFunc`, and iterate struct fields with `types.Struct.Fields` instead of `NumFields` and `Field`
- `generator`: replace `sort.Slice` with `slices.SortFunc`
- `introspection`: rename the misspelled `typeVale` to `typeValue`

## Why

`errors.AsType`, `slices.SortFunc` and `types.Struct.Fields` are all available in Go 1.26, so neither the `toolchain` nor the `go` directive needs to change. They replace reflection-based and index-based patterns with generic, iterator-based equivalents.

Both `sort.Slice` and `slices.SortFunc` are unstable sorts, so the deterministic output the sorting exists for is unchanged.

## Verification

- `go vet ./...` is clean
- `go test -race ./...` passes
- `make fmt` is idempotent
- `make compat` (gorelease) infers `v0.38.0` and suggests `v0.38.1`, so there is no API change
- Regenerating the 7 local-schema examples produces no diff

The 3 examples backed by a remote endpoint (`annictV2`, `github`, `files-info`) were not regenerated because they require network access and credentials.