### PR TITLE
refactor: remove duplicated code

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -802,21 +802,16 @@ func (e *Encoder) encodeSlice(v reflect.Value) ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	result := make([]json.RawMessage, v.Len())
-	for i := range v.Len() {
-		encodedValue, err := e.Encode(v.Index(i))
-		if err != nil {
-			return nil, err
-		}
-
-		result[i] = encodedValue
-	}
-
-	return json.Marshal(result)
+	return e.encodeElements(v)
 }
 
 // encodeArray encodes an array value
 func (e *Encoder) encodeArray(v reflect.Value) ([]byte, error) {
+	return e.encodeElements(v)
+}
+
+// encodeElements encodes each element of an indexable value as a JSON array
+func (e *Encoder) encodeElements(v reflect.Value) ([]byte, error) {
 	result := make([]json.RawMessage, v.Len())
 	for i := range v.Len() {
 		encodedValue, err := e.Encode(v.Index(i))

--- a/introspection/parse.go
+++ b/introspection/parse.go
@@ -154,10 +154,7 @@ func (p parser) parseInputObjectFields(typeValue *FullType) ast.FieldList {
 func (p parser) parseObjectTypeDefinition(typeValue *FullType) *ast.Definition {
 	fieldList := p.parseObjectFields(typeValue)
 
-	interfaces := make([]string, 0, len(typeValue.Interfaces))
-	for _, intf := range typeValue.Interfaces {
-		interfaces = append(interfaces, pointerString(intf.Name))
-	}
+	interfaces := interfaceNames(typeValue)
 
 	enums := make(ast.EnumValueList, 0, len(typeValue.EnumValues))
 	for _, enum := range typeValue.EnumValues {
@@ -184,10 +181,7 @@ func (p parser) parseObjectTypeDefinition(typeValue *FullType) *ast.Definition {
 func (p parser) parseInterfaceTypeDefinition(typeValue *FullType) *ast.Definition {
 	fieldList := p.parseObjectFields(typeValue)
 
-	interfaces := make([]string, 0, len(typeValue.Interfaces))
-	for _, intf := range typeValue.Interfaces {
-		interfaces = append(interfaces, pointerString(intf.Name))
-	}
+	interfaces := interfaceNames(typeValue)
 
 	return &ast.Definition{
 		Kind:        ast.Interface,
@@ -203,10 +197,7 @@ func (p parser) parseInterfaceTypeDefinition(typeValue *FullType) *ast.Definitio
 func (p parser) parseInputObjectTypeDefinition(typeValue *FullType) *ast.Definition {
 	fieldList := p.parseInputObjectFields(typeValue)
 
-	interfaces := make([]string, 0, len(typeValue.Interfaces))
-	for _, intf := range typeValue.Interfaces {
-		interfaces = append(interfaces, pointerString(intf.Name))
-	}
+	interfaces := interfaceNames(typeValue)
 
 	return &ast.Definition{
 		Kind:        ast.InputObject,
@@ -422,6 +413,16 @@ func builtInEnum(fullType *FullType) bool {
 	name := pointerString(fullType.Name)
 
 	return strings.HasPrefix(name, "__")
+}
+
+// interfaceNames collects the names of the interfaces the type implements
+func interfaceNames(fullType *FullType) []string {
+	interfaces := make([]string, 0, len(fullType.Interfaces))
+	for _, intf := range fullType.Interfaces {
+		interfaces = append(interfaces, pointerString(intf.Name))
+	}
+
+	return interfaces
 }
 
 func builtInObject(fullType *FullType) bool {


### PR DESCRIPTION
## Summary

Remove two blocks of duplicated code. There is no behavior change.

- `clientv2`: `encodeSlice` and `encodeArray` contained an identical loop. It now lives in `encodeElements`, and `encodeSlice` keeps only its own nil handling before delegating.
- `introspection`: three definition parsers repeated the same interface name collection. It now lives in the `interfaceNames` helper.

## Why

Both duplications were exact copies, so a single implementation removes the risk of the copies drifting apart. `interfaceNames` follows the free function style of the existing `pointerString` and `builtInObject`.

The similar-looking `unions` block in `parseUnionTypeDefinition` reads `PossibleTypes` and dereferences the name directly, so it is deliberately left alone.

## Verification

- `go vet ./...` is clean
- `go test -race ./...` passes
- `make fmt` is idempotent
- `make compat` (gorelease) infers `v0.38.0` and suggests `v0.38.1`, so there is no API change
- Regenerating the 7 local-schema examples produces no diff

The 3 examples backed by a remote endpoint (`annictV2`, `github`, `files-info`) were not regenerated because they require network access and credentials.

## Note

This is the follow-up to #316. It is rebased onto `main` after that pull request was merged.