### PR TITLE
fix: use %g-style formatting in encodeFloat to fix Int variable encoding

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -634,7 +634,12 @@ func (e *Encoder) encodeUint(v reflect.Value) ([]byte, error) {
 
 // encodeFloat encodes a floating-point value
 func (e *Encoder) encodeFloat(v reflect.Value) ([]byte, error) {
-	return fmt.Appendf(nil, "%f", v.Float()), nil
+	bitSize := 64
+	if v.Kind() == reflect.Float32 {
+		bitSize = 32
+	}
+
+	return strconv.AppendFloat(nil, v.Float(), 'g', -1, bitSize), nil
 }
 
 // encodeString encodes a string value

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -1691,6 +1691,55 @@ func TestEncoder_encodeStruct(t *testing.T) {
 	}
 }
 
+func TestEncoder_encodeFloat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{
+			name:  "whole number float encoded without decimal point",
+			input: float64(1),
+			want:  "1",
+		},
+		{
+			name:  "negative whole number float encoded without decimal point",
+			input: float64(-1),
+			want:  "-1",
+		},
+		{
+			name:  "zero encoded as 0",
+			input: float64(0),
+			want:  "0",
+		},
+		{
+			name:  "fractional value keeps decimal point",
+			input: float64(1.5),
+			want:  "1.5",
+		},
+		{
+			name:  "float32 value does not gain spurious precision from float64 conversion",
+			input: float32(0.1),
+			want:  "0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoder := &Encoder{}
+
+			got, err := encoder.encodeFloat(reflect.ValueOf(tt.input))
+			if err != nil {
+				t.Fatalf("encodeFloat() error = %v", err)
+			}
+
+			if string(got) != tt.want {
+				t.Errorf("encodeFloat() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_isEmptyValue(t *testing.T) {
 	str := "test"
 


### PR DESCRIPTION
`clientv2.Encoder.encodeFloat` previously used `fmt.Appendf` with `%f`, which formats whole-number floats like 1.0 as "1.000000". When such values are sent as GraphQL Int-typed variables, the server fails to unmarshal them.

Switch to `strconv.FormatFloat` with `'g'` and `-1` precision, matching encoding/json behavior, so whole numbers are emitted without a decimal point and fractional values retain their precision. Use `bitSize` 32 for `reflect.Float32` to avoid introducing spurious precision from the `float64` intermediate value.

Fixes: #318
