### PR TITLE
fix(clientv2): encode json.Number as a JSON number

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -536,6 +536,10 @@ func (e *Encoder) Encode(v reflect.Value) ([]byte, error) {
 
 	t := v.Type()
 
+	if t == jsonNumberType {
+		return e.encodeJSONNumber(v)
+	}
+
 	switch t.Kind() {
 	case reflect.Pointer:
 		return e.encodePtr(v)
@@ -645,6 +649,21 @@ func (e *Encoder) encodeString(v reflect.Value) ([]byte, error) {
 	}
 
 	return stringValue, nil
+}
+
+var jsonNumberType = reflect.TypeFor[json.Number]()
+
+// encodeJSONNumber encodes a json.Number value as a JSON number.
+// json.Number does not implement json.Marshaler and its kind is reflect.String,
+// so it has to be handled before the ordinary string encoding.
+// Validation and the empty-string fallback to 0 are delegated to encoding/json.
+func (e *Encoder) encodeJSONNumber(v reflect.Value) ([]byte, error) {
+	numberValue, err := json.Marshal(json.Number(v.String()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode json.Number: %w", err)
+	}
+
+	return numberValue, nil
 }
 
 // trimQuotes removes double quotes from the beginning and end of a string

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -2014,3 +2014,105 @@ func TestClientPostEncodeNilSliceAsEmptyArray(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalJSONNumber(t *testing.T) {
+	t.Parallel()
+
+	type PriceInput struct {
+		Price json.Number `json:"price"`
+	}
+
+	type OptionalPriceInput struct {
+		Price json.Number `json:"price,omitempty"`
+	}
+
+	type PointerPriceInput struct {
+		Price *json.Number `json:"price"`
+	}
+
+	fractionalPrice := json.Number("1100.55")
+
+	tests := []struct {
+		name    string
+		v       any
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "integer json.Number",
+			v:    PriceInput{Price: json.Number("1100")},
+			want: []byte(`{"price":1100}`),
+		},
+		{
+			name: "fractional json.Number",
+			v:    PriceInput{Price: json.Number("1100.55")},
+			want: []byte(`{"price":1100.55}`),
+		},
+		{
+			name: "negative exponent json.Number",
+			v:    PriceInput{Price: json.Number("-1.5e3")},
+			want: []byte(`{"price":-1.5e3}`),
+		},
+		{
+			name: "top-level json.Number",
+			v:    json.Number("42"),
+			want: []byte(`42`),
+		},
+		{
+			name: "json.Number nested in map",
+			v:    map[string]any{"input": map[string]any{"price": json.Number("1100.55")}},
+			want: []byte(`{"input":{"price":1100.55}}`),
+		},
+		{
+			name: "json.Number nested in slice",
+			v:    []json.Number{json.Number("1"), json.Number("2.5")},
+			want: []byte(`[1,2.5]`),
+		},
+		{
+			name: "pointer to json.Number",
+			v:    PointerPriceInput{Price: &fractionalPrice},
+			want: []byte(`{"price":1100.55}`),
+		},
+		{
+			name: "nil pointer to json.Number",
+			v:    PointerPriceInput{},
+			want: []byte(`{"price":null}`),
+		},
+		{
+			name: "empty json.Number is encoded as 0 like encoding/json",
+			v:    PriceInput{},
+			want: []byte(`{"price":0}`),
+		},
+		{
+			name: "empty json.Number is omitted with omitempty",
+			v:    OptionalPriceInput{},
+			want: []byte(`{}`),
+		},
+		{
+			name:    "invalid json.Number returns an error",
+			v:       PriceInput{Price: json.Number("abc")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MarshalJSON(context.Background(), tt.v)
+			stdlibGot, stdlibErr := json.Marshal(tt.v)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Error(t, stdlibErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, string(tt.want), string(got))
+
+			// clientv2.MarshalJSON must agree with encoding/json on json.Number handling.
+			require.NoError(t, stdlibErr)
+			require.Equal(t, string(stdlibGot), string(got))
+		})
+	}
+}


### PR DESCRIPTION
## Background

`clientv2.MarshalJSON` encoded `json.Number` as a JSON string. `json.Number` does not implement `json.Marshaler` and its kind is `reflect.String`, so `Encoder.Encode` fell through to `encodeString` like any other string. `encoding/json` emits `json.Number` as a JSON number, so gqlgenc disagreed with the standard library and could break JSON scalar inputs whose consumers distinguish numbers from strings.

Fixes #328

## Changes

- Check for the `json.Number` type in `Encoder.Encode` before the kind switch and delegate to the new `encodeJSONNumber`.
- `encodeJSONNumber` hands the value to `encoding/json`, so the error for invalid literals and the empty-string fallback to `0` stay consistent with the standard library.
- Add `TestMarshalJSONNumber` with 11 cases: integer, fractional, exponent notation, top-level value, nested in map and slice, pointer, nil pointer, empty string, `omitempty`, and an invalid literal. The output is compared byte for byte, and the valid cases are also checked against `encoding/json`.

## Design note: why only `json.Number` is special-cased by type

- `encoding/json` does the same thing: `stringEncoder` checks `v.Type() == numberType` and writes the value as a number. `json.Number` is the only type it special-cases by type identity, and this PR mirrors that.
- `json.Number` deliberately does not implement `json.Marshaler`, so there is no interface to hook into. Third-party encoders such as json-iterator and goccy/go-json also detect it by type.
- Derived types such as `type MyNumber json.Number` are treated as plain strings by the standard library, and this PR behaves the same way.

The other types that `encoding/json` treats specially were compared against gqlgenc as well. `json.RawMessage` and `time.Time` already match through the `json.Marshaler` path, and map keys (int, `json.Number`, `encoding.TextMarshaler`) match too.

## Testing

The first commit adds only the test, and 9 of the 11 cases fail at that point. The second commit adds the fix and all cases pass.

```console
$ go test -race ./...
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.12.2
0 issues.
```

Output of the reproduction from the issue:

```text
{"price":1100.55} {"price":1100.55} <nil>
invalid: failed to encode json.Number: json: invalid number literal "abc"
```

## Out of scope

Pre-existing differences from `encoding/json` found during the comparison. Each one changes the output format, so they are left for separate issues.

- `[]byte`: the standard library emits a base64 string such as `"aGk="`, while gqlgenc encodes each element and emits `[104,105]`.
- Embedded structs: the standard library flattens their fields, while gqlgenc nests them under the type name.
- `float64` formatting: `1.5` becomes `1.500000` because of `%f`. The values are numerically equal.
- An invalid `json.Number` used as a map key: `encoding/json` does not validate keys, while this PR goes through `Encode` and returns an error. This has no practical impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
