### PR TITLE
chore: require Go 1.27 and update golangci-lint to v2.13.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,6 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.12.2
+          version: v2.13.2
       - run: make build
       - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - errname # No need to restrict error variable names, so ignoring
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5 # same reason as exhaustruct
     - forbidigo
     - funlen
     - gochecknoglobals

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/gqlgo/gqlgenc
 
-go 1.26
+go 1.27
 
-toolchain go1.26.4
+toolchain go1.27.1
 
 require (
 	github.com/99designs/gqlgen v0.17.91


### PR DESCRIPTION
## Background

`clientv2` currently encodes request variables with a hand-written reflect walker because `encoding/json` v1 has no hook for gqlgen's `MarshalGQL` convention. Go 1.27 ships `encoding/json/v2` as a stable package, and its `WithMarshalers` option provides exactly that hook, so the walker can be replaced with the standard library (see #328 for the kind of divergence the walker causes today).

This PR only raises the toolchain requirement and keeps CI working on it. The encoder migration follows in a separate PR so that each change can be released and reverted on its own.

## Changes

- `go.mod`: `go 1.26` → `go 1.27`, `toolchain go1.26.4` → `toolchain go1.27.1`.
- CI: golangci-lint `v2.12.2` → `v2.13.2`. Go 1.27 support landed in v2.13.0, and v2.12.2 fails on a Go 1.27 module.
- `.golangci.yml`: disable `exhaustruct_v5`. It was added in v2.13 and is enabled automatically by `default: all`; it is disabled for the same reason `exhaustruct` already is.

No Go source changes.

## Compatibility

Consumers on Go 1.26 or older will no longer be able to upgrade past this release. `gorelease` reports no API changes and suggests `v0.39.0` as the next version.

## Testing

```console
$ go version
go version go1.27.1 darwin/arm64
$ go build ./... && go test -race ./...
ok  	github.com/gqlgo/gqlgenc/clientgenv2
ok  	github.com/gqlgo/gqlgenc/clientv2
ok  	github.com/gqlgo/gqlgenc/config
ok  	github.com/gqlgo/gqlgenc/generator
ok  	github.com/gqlgo/gqlgenc/graphqljson
ok  	github.com/gqlgo/gqlgenc/introspection
ok  	github.com/gqlgo/gqlgenc/querydocument
$ golangci-lint run ./...   # v2.13.2
0 issues.
$ go tool gorelease
Inferred base version: v0.38.2
Suggested version: v0.39.0
```

The workflow was also run locally with `act` and the Build job passed.

## Out of scope

- `gomodguard` is deprecated in favor of `gomodguard_v2` since golangci-lint v2.12. It only emits a warning today, so the config is left as is.
- The `encoding/json/v2` based encoder itself (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
