### PR TITLE
fix(clientv2): report data decode failures under ParseDataWhenErrors

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -465,8 +465,10 @@ func (c *Client) unmarshal(data []byte, res any) error {
 
 	errData := graphqljson.UnmarshalData(resp.Data, res)
 	if errData != nil {
-		// if ParseDataWhenErrors is true, and we failed to unmarshal data, return the actual error
-		if c.ParseDataWhenErrors {
+		// With ParseDataWhenErrors, data may be partial or null when the response
+		// carries GraphQL errors, so report those errors instead of the decode
+		// failure. Without GraphQL errors the decode failure is the only error.
+		if c.ParseDataWhenErrors && err != nil {
 			return err
 		}
 

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -24,14 +24,14 @@ import (
 )
 
 const (
-	qqlSingleErr        = `{"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"}]}`
-	gqlMultipleErr      = `{"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"},{"path":["query GetUser"],"extensions":{"code":"variableNotUsed","variableName":"languageFirst"},"locations":[{"line":1,"column":1}],"message":"Variable $languageFirst is declared by GetUser but not used"},{"path":["fragment LanguageFragment"],"extensions":{"code":"useAndDefineFragment","fragmentName":"LanguageFragment"},"locations":[{"line":18,"column":1}],"message":"Fragment LanguageFragment was defined, but not used"}]}`
-	gqlDataAndErr       = `{"data": {"something": "some data"},"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"}]}`
-	invalidJSON         = "invalid"
-	validData           = `{"data":{"something": "some data"}}`
-	withBadDataFormat   = `{"data": "notAndObject"}`
+	qqlSingleErr            = `{"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"}]}`
+	gqlMultipleErr          = `{"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"},{"path":["query GetUser"],"extensions":{"code":"variableNotUsed","variableName":"languageFirst"},"locations":[{"line":1,"column":1}],"message":"Variable $languageFirst is declared by GetUser but not used"},{"path":["fragment LanguageFragment"],"extensions":{"code":"useAndDefineFragment","fragmentName":"LanguageFragment"},"locations":[{"line":18,"column":1}],"message":"Fragment LanguageFragment was defined, but not used"}]}`
+	gqlDataAndErr           = `{"data": {"something": "some data"},"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"}]}`
+	invalidJSON             = "invalid"
+	validData               = `{"data":{"something": "some data"}}`
+	withBadDataFormat       = `{"data": "notAndObject"}`
 	withBadDataFormatAndErr = `{"data": "notAndObject","errors":[{"message":"boom"}]}`
-	withBadErrorsFormat = `{"errors": "bad"}`
+	withBadErrorsFormat     = `{"errors": "bad"}`
 )
 
 type fakeRes struct {

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -30,6 +30,7 @@ const (
 	invalidJSON         = "invalid"
 	validData           = `{"data":{"something": "some data"}}`
 	withBadDataFormat   = `{"data": "notAndObject"}`
+	withBadDataFormatAndErr = `{"data": "notAndObject","errors":[{"message":"boom"}]}`
 	withBadErrorsFormat = `{"errors": "bad"}`
 )
 
@@ -216,6 +217,27 @@ func TestUnmarshal(t *testing.T) {
 		c := &Client{}
 		err := c.unmarshal([]byte(withBadDataFormat), r)
 		require.EqualError(t, err, "failed to decode data into response {\"data\": \"notAndObject\"}: : : : : json: cannot unmarshal string into Go value of type clientv2.fakeRes")
+	})
+
+	t.Run("bad data format with ParseDataWhenErrors and no graphql errors", func(t *testing.T) {
+		t.Parallel()
+
+		r := &fakeRes{}
+		c := &Client{ParseDataWhenErrors: true}
+		err := c.unmarshal([]byte(withBadDataFormat), r)
+		require.ErrorContains(t, err, "failed to decode data into response")
+	})
+
+	t.Run("bad data format with ParseDataWhenErrors and graphql errors returns the graphql errors", func(t *testing.T) {
+		t.Parallel()
+
+		r := &fakeRes{}
+		c := &Client{ParseDataWhenErrors: true}
+		err := c.unmarshal([]byte(withBadDataFormatAndErr), r)
+
+		var gqlErrors *GqlErrorList
+		require.ErrorAs(t, err, &gqlErrors)
+		require.Len(t, gqlErrors.Errors, 1)
 	})
 
 	t.Run("bad data format", func(t *testing.T) {


### PR DESCRIPTION
## Background

`Client.unmarshal` supports `ParseDataWhenErrors`, which decodes `data` even when the response carries GraphQL errors. When that option was enabled and the response had **no** GraphQL errors, a failure to decode `data` took the branch that returns the GraphQL error list, which was `nil` at that point. Callers received a half-populated result together with a nil error.

## Changes

- Return the GraphQL errors instead of the decode error only when there are GraphQL errors. Without them, the decode error is reported as it is for clients without the option.
- Tests: the first commit adds two cases to `TestUnmarshal` and fails on the first one; the second commit fixes it.
  - `ParseDataWhenErrors` on, undecodable `data`, no errors: returns the decode error.
  - `ParseDataWhenErrors` on, undecodable `data`, with errors: still returns `*GqlErrorList` (unchanged behavior).

## Testing

```console
$ go test -race ./clientv2/
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
