### PR TITLE
fix(clientgenv2): detect duplicate operation names

### DIFF
--- a/clientgenv2/source.go
+++ b/clientgenv2/source.go
@@ -127,10 +127,14 @@ func ValidateOperationList(os ast.OperationList) error {
 func IsUniqueName(os ast.OperationList) error {
 	operationNames := make(map[string]struct{})
 	for _, operation := range os {
-		_, exist := operationNames[templates.ToGo(operation.Name)]
+		goName := templates.ToGo(operation.Name)
+
+		_, exist := operationNames[goName]
 		if exist {
 			return fmt.Errorf("duplicate operation: %s", operation.Name)
 		}
+
+		operationNames[goName] = struct{}{}
 	}
 
 	return nil

--- a/clientgenv2/source_test.go
+++ b/clientgenv2/source_test.go
@@ -1,0 +1,54 @@
+package clientgenv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestValidateOperationList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		operationNames []string
+		wantErr        string
+	}{
+		{
+			name:           "distinct names",
+			operationNames: []string{"GetUser", "ListUsers"},
+		},
+		{
+			name:           "exact duplicate",
+			operationNames: []string{"GetUser", "GetUser"},
+			wantErr:        "duplicate operation: GetUser",
+		},
+		{
+			name:           "names that collide after conversion to Go",
+			operationNames: []string{"getUser", "get_user"},
+			wantErr:        "duplicate operation: get_user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			operations := make(ast.OperationList, 0, len(tt.operationNames))
+			for _, name := range tt.operationNames {
+				operations = append(operations, &ast.OperationDefinition{Name: name})
+			}
+
+			err := ValidateOperationList(operations)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## Background

`IsUniqueName` is meant to reject query documents that define two operations with the same name, including names that only collide once converted to Go identifiers (for example `getUser` and `get_user` both become `GetUser`). It looked each name up in a set that nothing ever added to, so it could never report a duplicate. The generator then emitted two methods with the same name and the user saw a Go compile error instead of a gqlgenc error.

## Changes

- Record each Go name in the set after checking it, so the second occurrence is reported as `duplicate operation: <name>`.
- Tests: the first commit adds `TestValidateOperationList` with three cases (distinct names, exact duplicate, collision after conversion to Go) and fails on both duplicate cases; the second commit fixes it.

## Testing

```console
$ go test -race ./clientgenv2/ ./generator/
ok  	github.com/gqlgo/gqlgenc/clientgenv2
ok  	github.com/gqlgo/gqlgenc/generator
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
