### PR TITLE
fix(generator): do not panic when Config.Generate is nil

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -49,6 +49,12 @@ func mutateHook(cfg *config.Config, usedTypes map[string]bool) func(b *modelgen.
 }
 
 func Generate(ctx context.Context, cfg *config.Config) error {
+	// LoadConfig always sets Generate, but callers that build Config by hand may
+	// leave it nil. Normalize it once so the plugin and the model hook can rely on it.
+	if cfg.Generate == nil {
+		cfg.Generate = &config.GenerateConfig{}
+	}
+
 	_ = syscall.Unlink(cfg.Client.Filename)
 	if cfg.Model.IsDefined() {
 		_ = syscall.Unlink(cfg.Model.Filename)
@@ -111,10 +117,7 @@ func Generate(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf(": %w", err)
 	}
 
-	var clientGen api.Option
-	if cfg.Generate != nil {
-		clientGen = api.AddPlugin(clientgenv2.New(queryDocument, operationQueryDocuments, cfg.Client, cfg.Generate))
-	}
+	clientGen := api.AddPlugin(clientgenv2.New(queryDocument, operationQueryDocuments, cfg.Client, cfg.Generate))
 
 	var plugins []plugin.Plugin
 

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -83,6 +83,24 @@ func (s *Suite) TestGenerator_withTestData() {
 	}
 }
 
+// TestGenerator_nilGenerateConfig verifies that Generate tolerates a Config
+// whose Generate section was left unset by a caller that built it by hand.
+func (s *Suite) TestGenerator_nilGenerateConfig() {
+	s.useDirForTest(filepath.Join("testdata", "multiple_queries"))
+
+	cfg, err := config.LoadConfig("./gqlgenc.yml")
+	s.Require().NoError(err)
+
+	cfg.GQLConfig.SkipValidation = true
+	cfg.GQLConfig.SkipModTidy = true
+	cfg.Generate = nil
+
+	s.Require().NotPanics(func() {
+		err = generator.Generate(context.Background(), cfg)
+	})
+	s.Require().NoError(err)
+}
+
 // useDir changes the current working directory to the given directory
 // and returns a function that can be used to restore the original
 // working directory.


### PR DESCRIPTION
## Background

`generator.Generate` is exported and can be called with a `Config` built by hand, not only with one produced by `config.LoadConfig` (the generator test suite already does this for `LoadSchema`). It stored the client plugin option only when `cfg.Generate` was set but invoked that option unconditionally, and the model hook dereferenced `cfg.Generate` too. A `Config` without a `Generate` section therefore crashed with a nil function call instead of generating with defaults.

## Changes

- Normalize `cfg.Generate` to an empty `GenerateConfig` at the start of `Generate`, matching what `clientgenv2.New` already does for its own argument, and drop the conditional around the plugin option.
- Tests: the first commit adds `TestGenerator_nilGenerateConfig`, which loads a testdata config, clears `Generate`, and requires `Generate` to neither panic nor fail. It fails until the fix in the second commit.

## Testing

```console
$ go test -race ./generator/
ok  	github.com/gqlgo/gqlgenc/generator
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
