### PR TITLE
fix(graphqljson): surface the tokenizer error for trailing input

### DIFF
--- a/graphqljson/graphql.go
+++ b/graphqljson/graphql.go
@@ -54,13 +54,14 @@ func UnmarshalData(data json.RawMessage, v any) error {
 	}
 
 	tok, err := d.jsonDecoder.Token()
-	switch err {
-	case io.EOF:
+	if errors.Is(err, io.EOF) {
 		// Expect to get io.EOF. There shouldn't be any more
 		// tokens left after we've decoded v successfully.
 		return nil
-	case nil:
-		return fmt.Errorf("invalid token '%v' after top-level value", tok)
+	}
+
+	if err != nil {
+		return fmt.Errorf("invalid input after top-level value: %w", err)
 	}
 
 	return fmt.Errorf("invalid token '%v' after top-level value", tok)

--- a/graphqljson/graphql_test.go
+++ b/graphqljson/graphql_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gqlgo/gqlgenc/graphqljson"
 )
@@ -1063,5 +1064,37 @@ func TestUnmarshalGraphQL_nestedFragmentSpread_multiLevel(t *testing.T) {
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("mismatch:\n%s", diff)
+	}
+}
+
+func TestUnmarshalData_trailingInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name:    "trailing token",
+			data:    `{"name": "Luke"} 2`,
+			wantErr: "invalid token '2' after top-level value",
+		},
+		{
+			name:    "trailing malformed input",
+			data:    `{"name": "Luke"} }`,
+			wantErr: "invalid character '}'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got struct{ Name string }
+
+			err := graphqljson.UnmarshalData([]byte(tt.data), &got)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
 	}
 }


### PR DESCRIPTION
## Background

After decoding the top-level value, `UnmarshalData` reads one more token to make sure nothing follows. When that read returned a tokenizer error (malformed trailing input), the error was discarded and the caller saw `invalid token '<nil>' after top-level value`, which does not say what was wrong. The last two branches were also duplicates of each other.

## Changes

- Wrap the tokenizer error as `invalid input after top-level value: <tokenizer error>`, keep the `invalid token '<tok>' after top-level value` message for a well-formed trailing token, and use `errors.Is` for the `io.EOF` check.
- Tests: the first commit adds `TestUnmarshalData_trailingInput` with a trailing token case and a malformed trailing input case; the second case fails until the fix in the second commit.

## Testing

```console
$ go test -race ./graphqljson/ ./clientv2/
ok  	github.com/gqlgo/gqlgenc/graphqljson
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
