### PR TITLE
fix(graphqljson): handle a null __typename without losing sync

### DIFF
--- a/graphqljson/graphql.go
+++ b/graphqljson/graphql.go
@@ -147,8 +147,14 @@ func (d *Decoder) decode() error { //nolint:maintidx
 			// If this key is __typename, eagerly read its value so we can use it
 			// to discriminate which inline fragment pointers to initialize below.
 			// This must happen before the nil-pointer init loop.
-			var earlyReadTok json.Token
+			var (
+				earlyReadTok json.Token
+				earlyRead    bool
+			)
+
 			if key == "__typename" {
+				earlyRead = true
+
 				earlyReadTok, err = d.jsonDecoder.Token()
 				if err == io.EOF {
 					return errors.New("unexpected end of JSON input")
@@ -197,7 +203,8 @@ func (d *Decoder) decode() error { //nolint:maintidx
 			// Read the next token, which should be the value.
 			// If it's of json.RawMessage or map type, decode the value.
 			// Skip reading if we already eagerly read the value above (for __typename).
-			if earlyReadTok != nil {
+			// A null __typename yields a nil token, so track the read with a flag.
+			if earlyRead {
 				tok = earlyReadTok
 			} else {
 				switch matchingFieldValue.Type() {

--- a/graphqljson/graphql_test.go
+++ b/graphqljson/graphql_test.go
@@ -1098,3 +1098,39 @@ func TestUnmarshalData_trailingInput(t *testing.T) {
 		})
 	}
 }
+
+// TestUnmarshalGraphQL_typenameNull verifies that a null __typename does not
+// desynchronize the token stream: the following fields must still be decoded.
+func TestUnmarshalGraphQL_typenameNull(t *testing.T) {
+	t.Parallel()
+
+	type query struct {
+		Node struct {
+			Typename *string `graphql:"__typename"`
+			Name     string  `graphql:"name"`
+			ID       string  `graphql:"id"`
+		} `graphql:"node"`
+	}
+
+	var got query
+
+	err := graphqljson.UnmarshalData([]byte(`{
+		"node": {
+			"__typename": null,
+			"name": "Luke Skywalker",
+			"id": "1"
+		}
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var want query
+
+	want.Node.Name = "Luke Skywalker"
+	want.Node.ID = "1"
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
## Background

The decoder reads the value of `__typename` eagerly so it can decide which inline fragment pointer to initialize before descending into the object, and it used a nil token as the "already read" marker. A JSON `null` is also a nil token, so for `"__typename": null` the decoder read the **next key** as the value and decoded the rest of the object one token out of phase. In practice this surfaced as errors such as `struct field for "Luke Skywalker" doesn't exist`.

Real servers rarely return a null `__typename`, but the decoder must not depend on that.

## Changes

- Track the eager read with an explicit boolean instead of testing the token for nil.
- Tests: the first commit adds `TestUnmarshalGraphQL_typenameNull`, which decodes an object whose `__typename` is null followed by two more fields; it fails until the fix in the second commit.

## Testing

```console
$ go test -race ./graphqljson/ ./clientv2/
ok  	github.com/gqlgo/gqlgenc/graphqljson
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
