### PR TITLE
fix(clientv2): close the multipart writer once

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -346,7 +346,6 @@ func prepareMultipartFormBody(
 	buffer *bytes.Buffer, formFields []FormField, files []MultipartFilesGroup,
 ) (string, error) {
 	writer := multipart.NewWriter(buffer)
-	defer writer.Close()
 
 	// form fields
 	for _, field := range formFields {

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 	"uuid"
@@ -411,6 +413,39 @@ func Test_prepareMultipartFormBody(t *testing.T) {
 
 		require.Contains(t, contentType, "multipart/form-data; boundary=")
 		require.NoError(t, err)
+	})
+
+	t.Run("body is terminated exactly once", func(t *testing.T) {
+		t.Parallel()
+
+		body := new(bytes.Buffer)
+		formFields := []FormField{{Name: "operations", Value: "value"}}
+		files := []MultipartFilesGroup{{Files: []MultipartFile{{
+			Index: 0,
+			File:  graphql.Upload{Filename: "file.txt", File: bytes.NewReader([]byte("content"))},
+		}}}}
+
+		contentType, err := prepareMultipartFormBody(body, formFields, files)
+		require.NoError(t, err)
+
+		boundary := strings.TrimPrefix(contentType, "multipart/form-data; boundary=")
+		require.Equal(t, 1, strings.Count(body.String(), "--"+boundary+"--"), "closing boundary must appear once:\n%s", body.String())
+
+		reader := multipart.NewReader(bytes.NewReader(body.Bytes()), boundary)
+
+		var partNames []string
+
+		for {
+			part, err := reader.NextPart()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			require.NoError(t, err)
+			partNames = append(partNames, part.FormName())
+		}
+
+		require.Equal(t, []string{"operations", "0"}, partNames)
 	})
 }
 


### PR DESCRIPTION
## Background

`prepareMultipartFormBody` deferred `writer.Close` and also called it explicitly at the end. `multipart.Writer.Close` unconditionally writes the closing boundary, so every multipart request body ended with two `--<boundary>--` terminators. Most parsers treat the second one as epilogue, but the body was malformed, and the existing test only checked the Content-Type string.

## Changes

- Drop the deferred `Close`. The explicit call remains; on the error paths the body is discarded anyway.
- Tests: the first commit adds a case that parses the produced body with `multipart.NewReader` and requires exactly one closing boundary and the expected parts; it fails until the fix in the second commit.

## Testing

```console
$ go test -race ./clientv2/
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
