### PR TITLE
fix(clientv2): skip nil elements in upload slices

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -316,11 +316,19 @@ func parseMultipartFiles(
 
 			i++
 		case []*graphql.Upload:
-			vars[k] = make([]struct{}, len(item))
+			// Placeholders for the files; nil elements stay null in the operations body.
+			placeholders := make([]any, len(item))
+			vars[k] = placeholders
 
 			groupFiles := make([]MultipartFile, 0, len(item))
 
 			for itemI, itemV := range item {
+				if itemV == nil {
+					continue
+				}
+
+				placeholders[itemI] = struct{}{}
+
 				iStr := strconv.Itoa(i)
 				mapping[iStr] = []string{fmt.Sprintf("variables.%s.%s", k, strconv.Itoa(itemI))}
 

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -545,6 +545,36 @@ func Test_parseMultipartFiles(t *testing.T) {
 		require.Len(t, multipartFilesGroups[0].Files, 2)
 		require.ElementsMatch(t, fieldFiles, make([]struct{}, 2))
 	})
+
+	t.Run("has a nil file in files", func(t *testing.T) {
+		t.Parallel()
+
+		vars := map[string]any{
+			"fieldFiles": []*graphql.Upload{
+				{
+					Filename: "file.txt",
+					File:     bytes.NewReader([]byte("content")),
+				},
+				nil,
+			},
+		}
+
+		var (
+			multipartFilesGroups []MultipartFilesGroup
+			mapping              map[string][]string
+			varsMutated          map[string]any
+		)
+
+		require.NotPanics(t, func() {
+			multipartFilesGroups, mapping, varsMutated = parseMultipartFiles(vars)
+		})
+
+		require.Equal(t, map[string][]string{"0": {"variables.fieldFiles.0"}}, mapping)
+		require.Len(t, multipartFilesGroups, 1)
+		require.Len(t, multipartFilesGroups[0].Files, 1)
+		require.Equal(t, 0, multipartFilesGroups[0].Files[0].Index)
+		require.Equal(t, []any{struct{}{}, nil}, varsMutated["fieldFiles"])
+	})
 }
 
 type Number int64


### PR DESCRIPTION
## Background

`parseMultipartFiles` dereferenced every element of a `[]*graphql.Upload` variable. A `[Upload]` input may legitimately contain `null` elements, so a nil element crashed the client with a nil pointer dereference.

## Changes

- Skip nil elements. The multipart `map` indexes stay contiguous for the remaining files, and the `operations` body carries `null` at the position of the missing element (present files keep the `{}` placeholder as before).
- Tests: the first commit adds a case with a nil element that requires no panic, the expected mapping, one file, and the `[{}, null]` placeholders; it panics until the fix in the second commit.

## Testing

```console
$ go test -race ./clientv2/
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
