### PR TITLE
fix(clientv2): stop modifying the caller's variables in Post

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"strconv"
@@ -272,6 +273,10 @@ func (c *Client) Post(ctx context.Context, operationName, query string, respData
 func parseMultipartFiles(
 	vars map[string]any,
 ) ([]MultipartFilesGroup, map[string][]string, map[string]any) {
+	// Work on a copy: the caller may reuse its map, for example when a
+	// request interceptor retries the request.
+	vars = maps.Clone(vars)
+
 	var (
 		multipartFilesGroups []MultipartFilesGroup
 		mapping              = map[string][]string{}

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -610,6 +610,23 @@ func Test_parseMultipartFiles(t *testing.T) {
 		require.Equal(t, 0, multipartFilesGroups[0].Files[0].Index)
 		require.Equal(t, []any{struct{}{}, nil}, varsMutated["fieldFiles"])
 	})
+
+	t.Run("does not modify the caller's vars", func(t *testing.T) {
+		t.Parallel()
+
+		upload := graphql.Upload{Filename: "file.txt", File: bytes.NewReader([]byte("content"))}
+		vars := map[string]any{
+			"field":      "val",
+			"fieldFile":  upload,
+			"fieldFiles": []*graphql.Upload{&upload},
+		}
+
+		_, _, varsForRequest := parseMultipartFiles(vars)
+
+		require.Nil(t, varsForRequest["fieldFile"])
+		require.Equal(t, upload, vars["fieldFile"], "the caller's map must keep the upload")
+		require.Equal(t, []*graphql.Upload{&upload}, vars["fieldFiles"], "the caller's map must keep the uploads")
+	})
 }
 
 type Number int64


### PR DESCRIPTION
## Background

`parseMultipartFiles` replaced uploads with placeholders directly in the map the caller passed to `Client.Post`, and also returned that same map. A caller that reuses its variables map, for example a request interceptor that retries the request, sent `null` instead of the files on the next attempt.

## Changes

- Clone the map before rewriting it. The request keeps using the returned copy; the caller's map is left untouched.
- Tests: the first commit adds a case asserting that the caller's map still holds the uploads after the call while the returned map has the placeholders; it fails until the fix in the second commit.

## Testing

```console
$ go test -race ./clientv2/
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
