### PR TITLE
fix(clientv2): encode multipart form fields with the client encoder

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -216,7 +216,8 @@ func (c *Client) Post(ctx context.Context, operationName, query string, respData
 	var headers []header
 
 	if len(multipartFilesGroups) > 0 {
-		contentType, err := prepareMultipartFormBody(
+		contentType, err := c.prepareMultipartFormBody(
+			ctx,
 			body,
 			[]FormField{
 				{
@@ -350,14 +351,17 @@ func parseMultipartFiles(
 	return multipartFilesGroups, mapping, vars
 }
 
-func prepareMultipartFormBody(
-	buffer *bytes.Buffer, formFields []FormField, files []MultipartFilesGroup,
+// prepareMultipartFormBody writes the multipart request body into buffer and
+// returns its Content-Type. Form fields are encoded with the client encoder so
+// that they follow the same rules as a JSON request body.
+func (c *Client) prepareMultipartFormBody(
+	ctx context.Context, buffer *bytes.Buffer, formFields []FormField, files []MultipartFilesGroup,
 ) (string, error) {
 	writer := multipart.NewWriter(buffer)
 
 	// form fields
 	for _, field := range formFields {
-		fieldBody, err := json.Marshal(field.Value)
+		fieldBody, err := c.marshalJSON(ctx, field.Value)
 		if err != nil {
 			return "", fmt.Errorf("encode %s: %w", field.Name, err)
 		}

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -393,7 +393,7 @@ func Test_prepareMultipartFormBody(t *testing.T) {
 			},
 		}
 
-		contentType, err := prepareMultipartFormBody(body, formFields, []MultipartFilesGroup{})
+		contentType, err := (&Client{}).prepareMultipartFormBody(context.Background(), body, formFields, []MultipartFilesGroup{})
 
 		require.Equal(t, contentType, "")
 		require.EqualError(t, err, "encode field: json: unsupported type: chan struct {}")
@@ -410,7 +410,7 @@ func Test_prepareMultipartFormBody(t *testing.T) {
 			},
 		}
 
-		contentType, err := prepareMultipartFormBody(body, formFields, []MultipartFilesGroup{})
+		contentType, err := (&Client{}).prepareMultipartFormBody(context.Background(), body, formFields, []MultipartFilesGroup{})
 
 		require.Contains(t, contentType, "multipart/form-data; boundary=")
 		require.NoError(t, err)
@@ -426,7 +426,7 @@ func Test_prepareMultipartFormBody(t *testing.T) {
 			File:  graphql.Upload{Filename: "file.txt", File: bytes.NewReader([]byte("content"))},
 		}}}}
 
-		contentType, err := prepareMultipartFormBody(body, formFields, files)
+		contentType, err := (&Client{}).prepareMultipartFormBody(context.Background(), body, formFields, files)
 		require.NoError(t, err)
 
 		boundary := strings.TrimPrefix(contentType, "multipart/form-data; boundary=")

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"reflect"
@@ -1748,7 +1749,8 @@ func TestEncoderNilSliceAsEmptyArray(t *testing.T) {
 }
 
 type captureHTTPClient struct {
-	body []byte
+	body        []byte
+	contentType string
 }
 
 func (c *captureHTTPClient) Do(req *http.Request) (*http.Response, error) {
@@ -1758,6 +1760,7 @@ func (c *captureHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	c.body = body
+	c.contentType = req.Header.Get("Content-Type")
 
 	return &http.Response{
 		StatusCode: http.StatusOK,
@@ -1948,4 +1951,37 @@ func TestMarshalJSONFloat(t *testing.T) {
 			require.Equal(t, tt.want, string(got))
 		})
 	}
+}
+
+// TestClientPostMultipartUsesClientEncoder verifies that the operations part of a
+// multipart request is encoded with the same rules as a JSON request body:
+// MarshalGQL scalars and the EncodeNilSliceAsEmptyArray option must apply.
+func TestClientPostMultipartUsesClientEncoder(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &captureHTTPClient{}
+	client := NewClient(httpClient, "https://example.com/graphql", &Options{EncodeNilSliceAsEmptyArray: true})
+
+	vars := map[string]any{
+		"file":   graphql.Upload{Filename: "file.txt", File: bytes.NewReader([]byte("content"))},
+		"number": NumberOne,
+		"ids":    []string(nil),
+	}
+
+	err := client.Post(context.Background(), "Upload", "mutation { upload }", &fakeRes{}, vars)
+	require.NoError(t, err)
+
+	_, params, err := mime.ParseMediaType(httpClient.contentType)
+	require.NoError(t, err)
+
+	reader := multipart.NewReader(bytes.NewReader(httpClient.body), params["boundary"])
+	form, err := reader.ReadForm(1 << 20)
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		`{"query":"mutation { upload }","variables":{"file":null,"number":"ONE","ids":[]},"operationName":"Upload"}`,
+		form.Value["operations"][0],
+	)
+	require.JSONEq(t, `{"0":["variables.file"]}`, form.Value["map"][0])
+	require.Len(t, form.File["0"], 1)
 }


### PR DESCRIPTION
## Background

The JSON request body is produced by `Client.marshalJSON`, which applies the gqlgen `MarshalGQL` conventions and the `EncodeNilSliceAsEmptyArray` option. The `operations` and `map` form fields of a multipart request were produced by `encoding/json` directly instead. The same variables were therefore encoded differently depending on whether an `Upload` was attached: a `MarshalGQL` enum was sent as its Go integer, and a nil slice was sent as `null` even with the option enabled.

## Changes

- `prepareMultipartFormBody` becomes a `Client` method that takes the request context and encodes form fields with `marshalJSON`, so both request shapes share one encoder.
- Tests: the first commit adds `TestClientPostMultipartUsesClientEncoder`, an end-to-end `Post` with an upload, a `MarshalGQL` scalar, and a nil slice under `EncodeNilSliceAsEmptyArray`; it parses the multipart body and requires `"number":"ONE"` and `"ids":[]` in `operations`. It fails until the second commit. The existing direct tests of `prepareMultipartFormBody` are updated to the method form.

## Behavior change

Multipart requests that carried `MarshalGQL` scalars or relied on `EncodeNilSliceAsEmptyArray` now send what the JSON path already sent. Servers that accepted the previous Go-level encoding of such scalars only did so by accident.

## Testing

```console
$ go test -race ./clientv2/
ok  	github.com/gqlgo/gqlgenc/clientv2
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
