### PR TITLE
test(generator): clean the actual output and gate expected rewrites behind -update

### DIFF
--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -2,6 +2,7 @@ package generator_test
 
 import (
 	"context"
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,6 +26,8 @@ const (
 	expected = "expected"
 	actual   = "actual"
 )
+
+var update = flag.Bool("update", false, "rewrite the expected files with the generated output")
 
 func (s *Suite) TestGenerator_withTestData() {
 	dirs := s.getTestDirs()
@@ -58,11 +61,10 @@ func (s *Suite) TestGenerator_withTestData() {
 			s.Require().Len(pkgs, 1)
 			s.Empty(pkgs[0].Errors)
 
-			// reset expected files if there are no expected files,
-			// allowing reset of expected files by removing them
-			if len(expectedFiles) == 0 {
+			// rewrite the expected files from the generated output when -update is given
+			if *update {
 				for path, content := range actualFiles {
-					s.T().Logf("resetting expected file %s", path)
+					s.T().Logf("updating expected file %s", path)
 					expectedPath := filepath.Join(expected, path)
 					_ = os.MkdirAll(filepath.Dir(expectedPath), 0o700)
 					err = os.WriteFile(expectedPath, []byte(content), 0o644)
@@ -71,6 +73,8 @@ func (s *Suite) TestGenerator_withTestData() {
 
 				return
 			}
+
+			s.Require().NotEmpty(expectedFiles, "no expected files found; run with -update to create them")
 
 			// compare expected and actual files
 			for path, expectedContent := range expectedFiles {
@@ -101,21 +105,11 @@ func (s *Suite) TestGenerator_nilGenerateConfig() {
 	s.Require().NoError(err)
 }
 
-// useDir changes the current working directory to the given directory
-// and returns a function that can be used to restore the original
-// working directory.
+// useDirForTest removes the actual output of a previous run and changes the
+// working directory to dir for the rest of the test; t.Chdir restores it.
 func (s *Suite) useDirForTest(dir string) {
-	wd, err := os.Getwd()
-	s.Require().NoError(err)
-	err = os.Chdir(dir)
-	s.Require().NoError(err)
-
-	// cleanup actual directory
-	_ = os.RemoveAll(filepath.Join(dir, actual))
-
-	s.T().Cleanup(func() {
-		s.Require().NoError(os.Chdir(wd))
-	})
+	s.Require().NoError(os.RemoveAll(filepath.Join(dir, actual)))
+	s.T().Chdir(dir)
 }
 
 func (s *Suite) loadFiles(dir string) map[string]string {


### PR DESCRIPTION
## Background

Two problems in the golden test harness of `generator`:

- `useDirForTest` changed the working directory and then removed `filepath.Join(dir, actual)`, but `dir` was already relative to the new working directory, so the `actual/` output of a previous run was never removed. A file the generator stops emitting would still be present and could mask a regression. The doc comment also described a return value that does not exist.
- When `expected/` was empty, the test wrote the generated output there and passed without asserting anything, so a lost `expected/` directory turned the suite green.

## Changes

- Remove `actual/` before changing directory, and use `t.Chdir`, which restores the working directory automatically.
- Require the expected files to exist, and rewrite them only when the test is run with `-update`, the usual Go idiom:

```console
$ go test ./generator/ -run TestSuite -update
```

Running with `-update` on main produces no diff, so the committed expected files are in sync with the generator.

## Testing

```console
$ go test -race ./generator/
ok  	github.com/gqlgo/gqlgenc/generator
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
