### PR TITLE
fix: derive the -version output from the build info

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,12 +5,16 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/gqlgo/gqlgenc/config"
 	"github.com/gqlgo/gqlgenc/generator"
 )
 
-var version = "0.33.0"
+// version can be set at build time with -ldflags "-X main.version=v1.2.3".
+// When it is empty, the version recorded in the module build info is used,
+// which is the requested version for binaries installed with go install.
+var version = ""
 
 func main() {
 	var (
@@ -22,7 +26,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Println(version)
+		fmt.Println(resolveVersion(version))
 
 		return
 	}
@@ -42,4 +46,31 @@ func main() {
 
 		os.Exit(4)
 	}
+}
+
+// resolveVersion returns the version to print for -version.
+//
+// Arguments:
+//   - override: the value set at build time with -ldflags, or empty
+//
+// Returns:
+//   - string: override when it is set, otherwise the main module version from
+//     the build info, or "(devel)" when no build info is available
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - the result is never empty
+func resolveVersion(override string) string {
+	if override != "" {
+		return override
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if ok && info.Main.Version != "" {
+		return info.Main.Version
+	}
+
+	return "(devel)"
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("build override wins", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, "v1.2.3", resolveVersion("v1.2.3"))
+	})
+
+	t.Run("falls back to the module build info", func(t *testing.T) {
+		t.Parallel()
+
+		got := resolveVersion("")
+		require.NotEmpty(t, got)
+		require.NotEqual(t, "0.33.0", got, "must not report a hardcoded version")
+	})
+}


### PR DESCRIPTION
## Background

`gqlgenc -version` printed a constant that was never updated, so every release since v0.33.0 reported `0.33.0`. Nothing in the Makefile or CI set it with `-ldflags`.

## Changes

- Use the main module version from `runtime/debug.ReadBuildInfo`, which `go install github.com/gqlgo/gqlgenc@v0.40.0` records as `v0.40.0`. Local builds print `(devel)`.
- Keep the `version` variable, now empty by default, as an override for build setups that pass `-ldflags "-X main.version=..."`.
- Tests: the first commit adds `TestResolveVersion` (override wins; fallback is never the old constant) and does not compile until the second commit adds `resolveVersion`.

```console
$ go run . -version
(devel)
$ go run -ldflags "-X main.version=v9.9.9" . -version
v9.9.9
```

## Testing

```console
$ go test -race ./
ok  	github.com/gqlgo/gqlgenc
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
