### PR TITLE
fix(clientgenv2): fail on unsupported getter types instead of emitting invalid Go

### DIFF
--- a/clientgenv2/template.go
+++ b/clientgenv2/template.go
@@ -51,22 +51,25 @@ type GenGettersGenerator struct {
 	ClientPackageName string
 }
 
-func (g *GenGettersGenerator) GenFunc() func(name string, p types.Type) string {
+func (g *GenGettersGenerator) GenFunc() func(name string, p types.Type) (string, error) {
 	// This method returns a string of getters for a struct.
 	// The idea is to be able to chain calls safely without having to check for nil.
 	// To make this work we need to return a pointer to the struct if the field is a struct.
-	return func(name string, p types.Type) string {
+	return func(name string, p types.Type) (string, error) {
 		var it *types.Struct
 
 		it, ok := p.(*types.Struct)
 		if !ok {
-			return ""
+			return "", nil
 		}
 
 		var buf bytes.Buffer
 
 		for field := range it.Fields() {
-			returns := g.returnTypeName(field.Type(), false)
+			returns, err := g.returnTypeName(field.Type(), false)
+			if err != nil {
+				return "", fmt.Errorf("getter %s.Get%s: %w", name, field.Name(), err)
+			}
 
 			buf.WriteString("func (t *" + name + ") Get" + field.Name() + "() " + returns + "{\n")
 			buf.WriteString("if t == nil {\n t = &" + name + "{}\n}\n")
@@ -79,7 +82,7 @@ func (g *GenGettersGenerator) GenFunc() func(name string, p types.Type) string {
 			buf.WriteString("return " + pointerOrNot + "t." + field.Name() + "\n}\n")
 		}
 
-		return buf.String()
+		return buf.String(), nil
 	}
 }
 
@@ -162,36 +165,75 @@ func (g *GenGettersGenerator) writeFieldAssignment(buf *bytes.Buffer, field *typ
 	}
 }
 
-func (g *GenGettersGenerator) returnTypeName(t types.Type, nested bool) string {
+// returnTypeName renders the Go type of a getter's return value.
+//
+// Arguments:
+//   - t: the field type
+//   - nested: true when t is an element of a pointer, slice, or map, in which
+//     case named types are not wrapped in a pointer
+//
+// Returns:
+//   - string: the Go type expression, qualified with the package name when the
+//     type comes from another package
+//   - error: non-nil when t is a kind the generator cannot express
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - a named type at the top level is returned as a pointer so that getters
+//     can be chained without nil checks
+func (g *GenGettersGenerator) returnTypeName(t types.Type, nested bool) (string, error) {
 	switch it := t.(type) {
 	case *types.Basic:
-		return it.String()
+		return it.String(), nil
 	case *types.Pointer:
-		return "*" + g.returnTypeName(it.Elem(), true)
+		elem, err := g.returnTypeName(it.Elem(), true)
+		if err != nil {
+			return "", err
+		}
+
+		return "*" + elem, nil
 	case *types.Slice:
-		return "[]" + g.returnTypeName(it.Elem(), true)
+		elem, err := g.returnTypeName(it.Elem(), true)
+		if err != nil {
+			return "", err
+		}
+
+		return "[]" + elem, nil
 	case *types.Named:
 		s := strings.Split(it.String(), ".")
 		name := s[len(s)-1]
 
-		isImported := it.Obj().Parent() != nil && it.Obj().Pkg().Name() != g.ClientPackageName
+		// Types from the universe scope such as error have no package.
+		isImported := it.Obj().Pkg() != nil && it.Obj().Pkg().Name() != g.ClientPackageName
 		if isImported {
 			name = namedTypeString(it)
 		}
 
 		if nested {
-			return name
+			return name, nil
 		}
 
-		return "*" + name
+		return "*" + name, nil
 	case *types.Interface:
-		return "any"
+		return "any", nil
 	case *types.Map:
-		return "map[" + g.returnTypeName(it.Key(), true) + "]" + g.returnTypeName(it.Elem(), true)
+		key, err := g.returnTypeName(it.Key(), true)
+		if err != nil {
+			return "", err
+		}
+
+		elem, err := g.returnTypeName(it.Elem(), true)
+		if err != nil {
+			return "", err
+		}
+
+		return "map[" + key + "]" + elem, nil
 	case *types.Alias:
 		return g.returnTypeName(it.Underlying(), nested)
 	default:
-		return fmt.Sprintf("%T----", it)
+		return "", fmt.Errorf("unsupported type %s (%T) in getter return type", t, t)
 	}
 }
 

--- a/clientgenv2/template_test.go
+++ b/clientgenv2/template_test.go
@@ -3,15 +3,20 @@ package clientgenv2
 import (
 	"go/types"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestReturnTypeName tests the returnTypeName function with various types.
 func TestReturnTypeName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    types.Type
 		nested   bool
 		expected string
+		wantErr  string
 	}{
 		{
 			name:     "Basic",
@@ -38,6 +43,12 @@ func TestReturnTypeName(t *testing.T) {
 			expected: "*MyType",
 		},
 		{
+			name:     "Named from the universe scope",
+			input:    types.Universe.Lookup("error").Type(),
+			nested:   true,
+			expected: "error",
+		},
+		{
 			name:     "Interface",
 			input:    types.NewInterfaceType(nil, nil).Complete(),
 			nested:   false,
@@ -49,6 +60,12 @@ func TestReturnTypeName(t *testing.T) {
 			nested:   false,
 			expected: "map[int]bool",
 		},
+		{
+			name:    "Unsupported",
+			input:   types.NewChan(types.SendRecv, types.Typ[types.Int]),
+			nested:  false,
+			wantErr: "unsupported type",
+		},
 	}
 
 	g := &GenGettersGenerator{
@@ -57,10 +74,17 @@ func TestReturnTypeName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			output := g.returnTypeName(test.input, test.nested)
-			if output != test.expected {
-				t.Errorf("Expected %s, but got %s", test.expected, output)
+			t.Parallel()
+
+			output, err := g.returnTypeName(test.input, test.nested)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+
+				return
 			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, output)
 		})
 	}
 }


### PR DESCRIPTION
## Background

`returnTypeName` renders the return type of the generated getters. For a kind it did not recognize (arrays, channels, function types, type parameters) it returned `"%T----"`, so the generator succeeded and the user got a Go compile error in the generated client with no hint that the generator was the cause. It also dereferenced `it.Obj().Pkg()` for every named type; that is nil for types from the universe scope such as `error`, which panics.

## Changes

- `returnTypeName` returns `(string, error)` and reports `unsupported type ... in getter return type` for kinds it cannot express. The `genGetters` template function returns the error, which `text/template` surfaces from `RenderTemplate`, so generation now fails with a message naming the struct and field.
- Skip the package qualification when a named type has no package instead of dereferencing nil.
- Tests: the first commit rewrites `TestReturnTypeName` for the new signature and adds a universe-scope `error` case and an unsupported `chan` case; it does not compile until the second commit. The golden tests in `generator` cover the template wiring.

## Testing

```console
$ go test -race ./clientgenv2/ ./generator/
ok  	github.com/gqlgo/gqlgenc/clientgenv2
ok  	github.com/gqlgo/gqlgenc/generator
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
