### PR TITLE
test(parsequery): cover LoadQuerySources and ParseQueryDocuments

### DIFF
--- a/parsequery/parse_test.go
+++ b/parsequery/parse_test.go
@@ -1,0 +1,81 @@
+package parsequery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestParseQueryDocuments(t *testing.T) {
+	t.Parallel()
+
+	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "schema.graphql", Input: `
+type Query {
+	user(id: ID!): User
+}
+
+type User {
+	id: ID!
+	name: String!
+}
+`})
+
+	tests := []struct {
+		name           string
+		sources        []*ast.Source
+		wantOperations []string
+		wantFragments  []string
+		wantErr        string
+	}{
+		{
+			name: "operations and fragments from several sources are merged",
+			sources: []*ast.Source{
+				{Name: "user.graphql", Input: `query GetUser($id: ID!) { user(id: $id) { ...UserFields } }`},
+				{Name: "fragments.graphql", Input: `fragment UserFields on User { id name }`},
+			},
+			wantOperations: []string{"GetUser"},
+			wantFragments:  []string{"UserFields"},
+		},
+		{
+			name:    "syntax error is reported",
+			sources: []*ast.Source{{Name: "broken.graphql", Input: `query GetUser { user(id: `}},
+			wantErr: "broken.graphql",
+		},
+		{
+			name:    "unknown field fails validation",
+			sources: []*ast.Source{{Name: "bad.graphql", Input: `query GetUser { user(id: "1") { email } }`}},
+			wantErr: "email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc, err := ParseQueryDocuments(schema, tt.sources)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			operations := make([]string, 0, len(doc.Operations))
+			for _, operation := range doc.Operations {
+				operations = append(operations, operation.Name)
+			}
+
+			fragments := make([]string, 0, len(doc.Fragments))
+			for _, fragment := range doc.Fragments {
+				fragments = append(fragments, fragment.Name)
+			}
+
+			require.Equal(t, tt.wantOperations, operations)
+			require.Equal(t, tt.wantFragments, fragments)
+		})
+	}
+}

--- a/parsequery/query_source_test.go
+++ b/parsequery/query_source_test.go
@@ -1,0 +1,91 @@
+package parsequery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func TestLoadQuerySources(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.graphql"), "query A { a }")
+	writeFile(t, filepath.Join(dir, "b.graphql"), "query B { b }")
+	writeFile(t, filepath.Join(dir, "nested", "deep", "c.graphql"), "query C { c }")
+	writeFile(t, filepath.Join(dir, "nested", "ignored.txt"), "not graphql")
+
+	tests := []struct {
+		name      string
+		patterns  []string
+		wantNames []string
+		wantErr   string
+	}{
+		{
+			name:      "explicit file",
+			patterns:  []string{filepath.Join(dir, "a.graphql")},
+			wantNames: []string{"a.graphql"},
+		},
+		{
+			name:      "glob in one directory",
+			patterns:  []string{filepath.Join(dir, "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql"},
+		},
+		{
+			name:      "double star walks subdirectories",
+			patterns:  []string{filepath.Join(dir, "**", "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql", "nested/deep/c.graphql"},
+		},
+		{
+			name:      "the same file matched twice is loaded once",
+			patterns:  []string{filepath.Join(dir, "a.graphql"), filepath.Join(dir, "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql"},
+		},
+		{
+			name:      "no match yields no sources",
+			patterns:  []string{filepath.Join(dir, "missing", "*.graphql")},
+			wantNames: []string{},
+		},
+		{
+			// filepath.Glob reports no match for a missing explicit path, so it is not an error today.
+			name:      "explicit missing file yields no sources",
+			patterns:  []string{filepath.Join(dir, "missing.graphql")},
+			wantNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sources, err := LoadQuerySources(tt.patterns)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(sources))
+			for _, source := range sources {
+				rel, err := filepath.Rel(dir, filepath.FromSlash(source.Name))
+				require.NoError(t, err)
+
+				names = append(names, filepath.ToSlash(rel))
+				require.NotEmpty(t, source.Input)
+			}
+
+			require.Equal(t, tt.wantNames, names)
+		})
+	}
+}


### PR DESCRIPTION
## Background

`parsequery` had no tests at all, although `LoadQuerySources` carries a copy of gqlgen's glob expansion and `ParseQueryDocuments` is the entry point for every query file. This PR adds the safety net before the upcoming refactors touch that code (deduplicating the glob expansion with `config`).

## Changes

- `TestLoadQuerySources`: explicit file, single-directory glob, `**` walk into subdirectories, the same file matched twice is loaded once, a pattern with no match, and the current behavior for a missing explicit path (`filepath.Glob` reports no match, so it is not an error today; the case documents that rather than changing it).
- `TestParseQueryDocuments`: operations and fragments from several sources are merged, a syntax error is reported with the file name, and an unknown field fails validation.

Coverage of `parsequery` goes from 0.0% to 94.5%. Test-only change.

## Testing

```console
$ go test -race -cover ./parsequery/
ok  	github.com/gqlgo/gqlgenc/parsequery	coverage: 94.5% of statements
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
