### PR TITLE
refactor: share the glob expansion between config and parsequery

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,15 +7,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
-	"strings"
 
 	"github.com/goccy/go-yaml"
 
 	"github.com/99designs/gqlgen/codegen/config"
 
 	"github.com/gqlgo/gqlgenc/clientv2"
+	"github.com/gqlgo/gqlgenc/internal/fileglob"
 	"github.com/gqlgo/gqlgenc/introspection"
 
 	"github.com/vektah/gqlparser/v2"
@@ -114,13 +113,6 @@ func findCfgInDir(dir string) string {
 	return ""
 }
 
-var path2regex = strings.NewReplacer(
-	`.`, `\.`,
-	`*`, `.+`,
-	`\`, `[\\/]`,
-	`/`, `[\\/]`,
-)
-
 // LoadConfig loads and parses the config gqlgenc config
 func LoadConfig(filename string) (*Config, error) {
 	var cfg Config
@@ -147,47 +139,9 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, fmt.Errorf("neither 'schema' nor 'endpoint' specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
 	}
 
-	// https://github.com/99designs/gqlgen/blob/3a31a752df764738b1f6e99408df3b169d514784/codegen/config/config.go#L120
-	files := StringList{}
-
-	for _, f := range cfg.SchemaFilename {
-		var matches []string
-
-		// for ** we want to override default globbing patterns and walk all
-		// subdirectories to match schema files.
-		if strings.Contains(f, "**") {
-			pathParts := strings.SplitN(f, "**", 2)
-			rest := strings.TrimPrefix(strings.TrimPrefix(pathParts[1], `\`), `/`)
-			// turn the rest of the glob into a regex, anchored only at the end because ** allows
-			// for any number of dirs in between and walk will let us match against the full path name
-			globRe := regexp.MustCompile(path2regex.Replace(rest) + `$`)
-
-			err := filepath.Walk(pathParts[0], func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if globRe.MatchString(strings.TrimPrefix(path, pathParts[0])) {
-					matches = append(matches, path)
-				}
-
-				return nil
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
-			}
-		} else {
-			matches, err = filepath.Glob(f)
-			if err != nil {
-				return nil, fmt.Errorf("failed to glob schema filename %s: %w", f, err)
-			}
-		}
-
-		for _, m := range matches {
-			if !files.Has(m) {
-				files = append(files, m)
-			}
-		}
+	files, err := fileglob.Expand(cfg.SchemaFilename)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(files) > 0 {

--- a/internal/fileglob/fileglob.go
+++ b/internal/fileglob/fileglob.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2020 gqlgen authors
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// Package fileglob expands the file patterns accepted by the schema and query
+// settings. It is a copy of the glob handling in gqlgen's config loading,
+// which gqlgen does not export.
+package fileglob
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+var path2regex = strings.NewReplacer(
+	`.`, `\.`,
+	`*`, `.+`,
+	`\`, `[\\/]`,
+	`/`, `[\\/]`,
+)
+
+// Expand resolves file patterns into the files they match.
+//
+// Arguments:
+//   - patterns: file paths or glob patterns; a pattern containing "**" matches any number of directories
+//
+// Returns:
+//   - []string: the matched paths in pattern order, each path listed once
+//   - error: non-nil if a pattern is malformed or a directory walk fails
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - a pattern that matches nothing contributes no paths and no error
+func Expand(patterns []string) ([]string, error) {
+	var files []string
+
+	for _, pattern := range patterns {
+		matches, err := expand(pattern)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, match := range matches {
+			if !slices.Contains(files, match) {
+				files = append(files, match)
+			}
+		}
+	}
+
+	return files, nil
+}
+
+// expand resolves one pattern.
+//
+// Arguments:
+//   - pattern: a file path or glob pattern
+//
+// Returns:
+//   - []string: the matched paths
+//   - error: non-nil if the pattern is malformed or a directory walk fails
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - none
+func expand(pattern string) ([]string, error) {
+	// for ** we want to override default globbing patterns and walk all
+	// subdirectories to match schema files.
+	if !strings.Contains(pattern, "**") {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob schema filename %s: %w", pattern, err)
+		}
+
+		return matches, nil
+	}
+
+	pathParts := strings.SplitN(pattern, "**", 2)
+	rest := strings.TrimPrefix(strings.TrimPrefix(pathParts[1], `\`), `/`)
+	// turn the rest of the glob into a regex, anchored only at the end because ** allows
+	// for any number of dirs in between and walk will let us match against the full path name
+	globRe := regexp.MustCompile(path2regex.Replace(rest) + `$`)
+
+	var matches []string
+
+	err := filepath.Walk(pathParts[0], func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if globRe.MatchString(strings.TrimPrefix(path, pathParts[0])) {
+			matches = append(matches, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
+	}
+
+	return matches, nil
+}

--- a/parsequery/parse_test.go
+++ b/parsequery/parse_test.go
@@ -1,0 +1,81 @@
+package parsequery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestParseQueryDocuments(t *testing.T) {
+	t.Parallel()
+
+	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "schema.graphql", Input: `
+type Query {
+	user(id: ID!): User
+}
+
+type User {
+	id: ID!
+	name: String!
+}
+`})
+
+	tests := []struct {
+		name           string
+		sources        []*ast.Source
+		wantOperations []string
+		wantFragments  []string
+		wantErr        string
+	}{
+		{
+			name: "operations and fragments from several sources are merged",
+			sources: []*ast.Source{
+				{Name: "user.graphql", Input: `query GetUser($id: ID!) { user(id: $id) { ...UserFields } }`},
+				{Name: "fragments.graphql", Input: `fragment UserFields on User { id name }`},
+			},
+			wantOperations: []string{"GetUser"},
+			wantFragments:  []string{"UserFields"},
+		},
+		{
+			name:    "syntax error is reported",
+			sources: []*ast.Source{{Name: "broken.graphql", Input: `query GetUser { user(id: `}},
+			wantErr: "broken.graphql",
+		},
+		{
+			name:    "unknown field fails validation",
+			sources: []*ast.Source{{Name: "bad.graphql", Input: `query GetUser { user(id: "1") { email } }`}},
+			wantErr: "email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc, err := ParseQueryDocuments(schema, tt.sources)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			operations := make([]string, 0, len(doc.Operations))
+			for _, operation := range doc.Operations {
+				operations = append(operations, operation.Name)
+			}
+
+			fragments := make([]string, 0, len(doc.Fragments))
+			for _, fragment := range doc.Fragments {
+				fragments = append(fragments, fragment.Name)
+			}
+
+			require.Equal(t, tt.wantOperations, operations)
+			require.Equal(t, tt.wantFragments, fragments)
+		})
+	}
+}

--- a/parsequery/query_source.go
+++ b/parsequery/query_source.go
@@ -26,70 +26,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 
-	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/gqlgo/gqlgenc/internal/fileglob"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-var path2regex = strings.NewReplacer(
-	`.`, `\.`,
-	`*`, `.+`,
-	`\`, `[\\/]`,
-	`/`, `[\\/]`,
-)
-
 // LoadQuerySources loads query sources from file names.
-// This is a modified copy of gqlgen's LoadConfig schema loading implementation.
-// Supports glob patterns like **/test/*.graphql.
+// Supports glob patterns like **/test/*.graphql; see internal/fileglob.
 func LoadQuerySources(queryFileNames []string) ([]*ast.Source, error) {
-	var noGlobQueryFileNames config.StringList
-
-	var err error
-
-	preGlobbing := queryFileNames
-	for _, f := range preGlobbing {
-		var matches []string
-
-		// for ** we want to override default globbing patterns and walk all
-		// subdirectories to match schema files.
-		if strings.Contains(f, "**") {
-			pathParts := strings.SplitN(f, "**", 2)
-			rest := strings.TrimPrefix(strings.TrimPrefix(pathParts[1], `\`), `/`)
-			// turn the rest of the glob into a regex, anchored only at the end because ** allows
-			// for any number of dirs in between and walk will let us match against the full path name
-			globRe := regexp.MustCompile(path2regex.Replace(rest) + `$`)
-
-			err := filepath.Walk(pathParts[0], func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if globRe.MatchString(strings.TrimPrefix(path, pathParts[0])) {
-					matches = append(matches, path)
-				}
-
-				return nil
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
-			}
-		} else {
-			matches, err = filepath.Glob(f)
-			if err != nil {
-				return nil, fmt.Errorf("failed to glob schema filename %v: %w", f, err)
-			}
-		}
-
-		for _, m := range matches {
-			if noGlobQueryFileNames.Has(m) {
-				continue
-			}
-
-			noGlobQueryFileNames = append(noGlobQueryFileNames, m)
-		}
+	noGlobQueryFileNames, err := fileglob.Expand(queryFileNames)
+	if err != nil {
+		return nil, err
 	}
 
 	querySources := make([]*ast.Source, 0, len(noGlobQueryFileNames))

--- a/parsequery/query_source_test.go
+++ b/parsequery/query_source_test.go
@@ -1,0 +1,91 @@
+package parsequery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func TestLoadQuerySources(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.graphql"), "query A { a }")
+	writeFile(t, filepath.Join(dir, "b.graphql"), "query B { b }")
+	writeFile(t, filepath.Join(dir, "nested", "deep", "c.graphql"), "query C { c }")
+	writeFile(t, filepath.Join(dir, "nested", "ignored.txt"), "not graphql")
+
+	tests := []struct {
+		name      string
+		patterns  []string
+		wantNames []string
+		wantErr   string
+	}{
+		{
+			name:      "explicit file",
+			patterns:  []string{filepath.Join(dir, "a.graphql")},
+			wantNames: []string{"a.graphql"},
+		},
+		{
+			name:      "glob in one directory",
+			patterns:  []string{filepath.Join(dir, "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql"},
+		},
+		{
+			name:      "double star walks subdirectories",
+			patterns:  []string{filepath.Join(dir, "**", "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql", "nested/deep/c.graphql"},
+		},
+		{
+			name:      "the same file matched twice is loaded once",
+			patterns:  []string{filepath.Join(dir, "a.graphql"), filepath.Join(dir, "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql"},
+		},
+		{
+			name:      "no match yields no sources",
+			patterns:  []string{filepath.Join(dir, "missing", "*.graphql")},
+			wantNames: []string{},
+		},
+		{
+			// filepath.Glob reports no match for a missing explicit path, so it is not an error today.
+			name:      "explicit missing file yields no sources",
+			patterns:  []string{filepath.Join(dir, "missing.graphql")},
+			wantNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sources, err := LoadQuerySources(tt.patterns)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(sources))
+			for _, source := range sources {
+				rel, err := filepath.Rel(dir, filepath.FromSlash(source.Name))
+				require.NoError(t, err)
+
+				names = append(names, filepath.ToSlash(rel))
+				require.NotEmpty(t, source.Input)
+			}
+
+			require.Equal(t, tt.wantNames, names)
+		})
+	}
+}


### PR DESCRIPTION
## Background

`config.LoadConfig` and `parsequery.LoadQuerySources` each carried a verbatim copy of gqlgen's glob handling: the `path2regex` replacer, the `**` directory walk, and the deduplication loop, about 35 lines in each place. gqlgen keeps that code unexported, so it cannot be called directly, but one copy is enough.

Stacked on #344, which adds the `parsequery` tests that cover this code; once #344 is merged this PR shows only the refactor.

## Changes

Pure refactor; the test suite is untouched.

- New `internal/fileglob.Expand(patterns) ([]string, error)`: resolves plain paths, single-directory globs, and `**` patterns, keeps the pattern order, and lists each file once. The gqlgen license header moves with the code.
- `LoadConfig` and `LoadQuerySources` call it and lose their private copies, including the second `path2regex` global. `LoadQuerySources` no longer needs gqlgen's `config.StringList`.

Net change in the two callers: +9 / −107 lines.

## Testing

```console
$ go test -race -cover ./internal/... ./parsequery/ ./config/ ./generator/
ok  	github.com/gqlgo/gqlgenc/parsequery	coverage: 94.1% of statements
ok  	github.com/gqlgo/gqlgenc/config	coverage: 67.5% of statements
ok  	github.com/gqlgo/gqlgenc/generator	coverage: 72.3% of statements
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

`internal/fileglob` is exercised through `TestLoadQuerySources` (all pattern kinds) and the `config` glob test. The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
