### PR TITLE
refactor(config): split LoadConfig into its steps

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,15 +7,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
-	"strings"
 
 	"github.com/goccy/go-yaml"
 
 	"github.com/99designs/gqlgen/codegen/config"
 
 	"github.com/gqlgo/gqlgenc/clientv2"
+	"github.com/gqlgo/gqlgenc/internal/fileglob"
 	"github.com/gqlgo/gqlgenc/introspection"
 
 	"github.com/vektah/gqlparser/v2"
@@ -114,13 +113,6 @@ func findCfgInDir(dir string) string {
 	return ""
 }
 
-var path2regex = strings.NewReplacer(
-	`.`, `\.`,
-	`*`, `.+`,
-	`\`, `[\\/]`,
-	`/`, `[\\/]`,
-)
-
 // LoadConfig loads and parses the config gqlgenc config
 func LoadConfig(filename string) (*Config, error) {
 	var cfg Config
@@ -147,47 +139,9 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, fmt.Errorf("neither 'schema' nor 'endpoint' specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
 	}
 
-	// https://github.com/99designs/gqlgen/blob/3a31a752df764738b1f6e99408df3b169d514784/codegen/config/config.go#L120
-	files := StringList{}
-
-	for _, f := range cfg.SchemaFilename {
-		var matches []string
-
-		// for ** we want to override default globbing patterns and walk all
-		// subdirectories to match schema files.
-		if strings.Contains(f, "**") {
-			pathParts := strings.SplitN(f, "**", 2)
-			rest := strings.TrimPrefix(strings.TrimPrefix(pathParts[1], `\`), `/`)
-			// turn the rest of the glob into a regex, anchored only at the end because ** allows
-			// for any number of dirs in between and walk will let us match against the full path name
-			globRe := regexp.MustCompile(path2regex.Replace(rest) + `$`)
-
-			err := filepath.Walk(pathParts[0], func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if globRe.MatchString(strings.TrimPrefix(path, pathParts[0])) {
-					matches = append(matches, path)
-				}
-
-				return nil
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
-			}
-		} else {
-			matches, err = filepath.Glob(f)
-			if err != nil {
-				return nil, fmt.Errorf("failed to glob schema filename %s: %w", f, err)
-			}
-		}
-
-		for _, m := range matches {
-			if !files.Has(m) {
-				files = append(files, m)
-			}
-		}
+	files, err := fileglob.Expand(cfg.SchemaFilename)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(files) > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -115,28 +115,14 @@ func findCfgInDir(dir string) string {
 
 // LoadConfig loads and parses the config gqlgenc config
 func LoadConfig(filename string) (*Config, error) {
-	var cfg Config
-
-	b, err := os.ReadFile(filename)
+	cfg, err := readConfig(filename)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read config: %w", err)
+		return nil, err
 	}
 
-	confContent := []byte(os.ExpandEnv(string(b)))
-
-	decoder := yaml.NewDecoder(bytes.NewReader(confContent), yaml.DisallowUnknownField())
-
-	err = decoder.Decode(&cfg)
+	err = cfg.checkSchemaSource()
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse config: %w", err)
-	}
-
-	if cfg.SchemaFilename != nil && cfg.Endpoint != nil {
-		return nil, fmt.Errorf("'schema' and 'endpoint' both specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
-	}
-
-	if cfg.SchemaFilename == nil && cfg.Endpoint == nil {
-		return nil, fmt.Errorf("neither 'schema' nor 'endpoint' specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
+		return nil, err
 	}
 
 	files, err := fileglob.Expand(cfg.SchemaFilename)
@@ -148,22 +134,82 @@ func LoadConfig(filename string) (*Config, error) {
 		cfg.SchemaFilename = files
 	}
 
-	models := make(config.TypeMap)
-	if cfg.Models != nil {
-		models = cfg.Models
+	sources, err := readSchemaSources(cfg.SchemaFilename)
+	if err != nil {
+		return nil, err
 	}
 
+	if cfg.Generate == nil {
+		cfg.Generate = &GenerateConfig{}
+	}
+
+	cfg.Generate.applyDefaults()
+
+	cfg.GQLConfig = cfg.newGQLConfig(sources)
+
+	err = cfg.Client.Check()
+	if err != nil {
+		return nil, fmt.Errorf("config.exec: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// readConfig reads and decodes a gqlgenc config file.
+//
+// Arguments:
+//   - filename: the path of the YAML file
+//
+// Returns:
+//   - *Config: the decoded config, without defaults applied
+//   - error: non-nil if the file cannot be read or contains unknown or malformed settings
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - environment variables referenced in the file are expanded before decoding
+func readConfig(filename string) (*Config, error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read config: %w", err)
+	}
+
+	confContent := []byte(os.ExpandEnv(string(b)))
+
+	decoder := yaml.NewDecoder(bytes.NewReader(confContent), yaml.DisallowUnknownField())
+
+	var cfg Config
+
+	err = decoder.Decode(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// readSchemaSources reads the schema files into parser sources.
+//
+// Arguments:
+//   - filenames: the schema files, already expanded from globs
+//
+// Returns:
+//   - []*ast.Source: one source per file, named by the slash-separated path; empty but not nil for no files
+//   - error: non-nil if a file cannot be read
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - the sources keep the order of filenames
+func readSchemaSources(filenames StringList) ([]*ast.Source, error) {
 	sources := []*ast.Source{}
 
-	for _, filename := range cfg.SchemaFilename {
+	for _, filename := range filenames {
 		filename = filepath.ToSlash(filename)
 
-		var (
-			err       error
-			schemaRaw []byte
-		)
-
-		schemaRaw, err = os.ReadFile(filename)
+		schemaRaw, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, fmt.Errorf("unable to open schema: %w", err)
 		}
@@ -171,58 +217,7 @@ func LoadConfig(filename string) (*Config, error) {
 		sources = append(sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
 	}
 
-	structFieldsAlwaysPointers := true
-	inlineFragmentAlwaysPointers := false
-	enableClientJsonOmitemptyTag := true
-
-	enableModelJsonOmitzeroTag := false
-	if cfg.Generate == nil {
-		cfg.Generate = &GenerateConfig{
-			StructFieldsAlwaysPointers:   &structFieldsAlwaysPointers,
-			InlineFragmentAlwaysPointers: &inlineFragmentAlwaysPointers,
-			EnableClientJsonOmitemptyTag: &enableClientJsonOmitemptyTag,
-			EnableClientJsonOmitzeroTag:  &enableModelJsonOmitzeroTag,
-		}
-	}
-
-	if cfg.Generate.StructFieldsAlwaysPointers == nil {
-		cfg.Generate.StructFieldsAlwaysPointers = &structFieldsAlwaysPointers
-	}
-
-	if cfg.Generate.InlineFragmentAlwaysPointers == nil {
-		cfg.Generate.InlineFragmentAlwaysPointers = &inlineFragmentAlwaysPointers
-	}
-
-	if cfg.Generate.EnableClientJsonOmitemptyTag == nil {
-		cfg.Generate.EnableClientJsonOmitemptyTag = &enableClientJsonOmitemptyTag
-	}
-
-	if cfg.Generate.EnableClientJsonOmitzeroTag == nil {
-		cfg.Generate.EnableClientJsonOmitzeroTag = &enableModelJsonOmitzeroTag
-	}
-
-	cfg.GQLConfig = &config.Config{
-		Model:    cfg.Model,
-		Models:   models,
-		AutoBind: cfg.AutoBind,
-		// TODO: gqlgen must be set exec but client not used
-		Exec:                           config.ExecConfig{Filename: "generated.go"},
-		Directives:                     map[string]config.DirectiveConfig{},
-		Sources:                        sources,
-		StructFieldsAlwaysPointers:     *cfg.Generate.StructFieldsAlwaysPointers,
-		ReturnPointersInUnmarshalInput: false,
-		ResolversAlwaysReturnPointers:  true,
-		NullableInputOmittable:         cfg.Generate.NullableInputOmittable,
-		EnableModelJsonOmitemptyTag:    cfg.Generate.EnableClientJsonOmitemptyTag,
-		EnableModelJsonOmitzeroTag:     cfg.Generate.EnableClientJsonOmitzeroTag,
-	}
-
-	err = cfg.Client.Check()
-	if err != nil {
-		return nil, fmt.Errorf("config.exec: %w", err)
-	}
-
-	return &cfg, nil
+	return sources, nil
 }
 
 // LoadSchema load and parses the schema from a local file or a remote server
@@ -291,4 +286,65 @@ func (c *Config) loadLocalSchema() (*ast.Schema, error) {
 	}
 
 	return schema, nil
+}
+
+// checkSchemaSource verifies that exactly one of schema and endpoint is set.
+//
+// Arguments:
+//   - none
+//
+// Returns:
+//   - error: non-nil if both or neither of the schema and endpoint settings are present
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - none
+func (c *Config) checkSchemaSource() error {
+	if c.SchemaFilename != nil && c.Endpoint != nil {
+		return fmt.Errorf("'schema' and 'endpoint' both specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
+	}
+
+	if c.SchemaFilename == nil && c.Endpoint == nil {
+		return fmt.Errorf("neither 'schema' nor 'endpoint' specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
+	}
+
+	return nil
+}
+
+// newGQLConfig projects the gqlgenc settings onto the gqlgen config used for generation.
+//
+// Arguments:
+//   - sources: the schema sources
+//
+// Returns:
+//   - *config.Config: the gqlgen config with the model, autobind, and generation settings applied
+//
+// Preconditions:
+//   - c.Generate is set and has its defaults applied
+//
+// Postconditions:
+//   - the returned config is not yet initialized; call Init after loading the schema
+func (c *Config) newGQLConfig(sources []*ast.Source) *config.Config {
+	models := make(config.TypeMap)
+	if c.Models != nil {
+		models = c.Models
+	}
+
+	return &config.Config{
+		Model:    c.Model,
+		Models:   models,
+		AutoBind: c.AutoBind,
+		// TODO: gqlgen must be set exec but client not used
+		Exec:                           config.ExecConfig{Filename: "generated.go"},
+		Directives:                     map[string]config.DirectiveConfig{},
+		Sources:                        sources,
+		StructFieldsAlwaysPointers:     *c.Generate.StructFieldsAlwaysPointers,
+		ReturnPointersInUnmarshalInput: false,
+		ResolversAlwaysReturnPointers:  true,
+		NullableInputOmittable:         c.Generate.NullableInputOmittable,
+		EnableModelJsonOmitemptyTag:    c.Generate.EnableClientJsonOmitemptyTag,
+		EnableModelJsonOmitzeroTag:     c.Generate.EnableClientJsonOmitzeroTag,
+	}
 }

--- a/config/generate_config.go
+++ b/config/generate_config.go
@@ -42,6 +42,56 @@ func (c *GenerateConfig) GetClientInterfaceName() *string {
 	return c.ClientInterfaceName
 }
 
+// applyDefaults fills the unset boolean options with their defaults.
+//
+// Arguments:
+//   - none
+//
+// Returns:
+//   - none
+//
+// Preconditions:
+//   - c is not nil
+//
+// Postconditions:
+//   - StructFieldsAlwaysPointers defaults to true, InlineFragmentAlwaysPointers to false,
+//     EnableClientJsonOmitemptyTag to true, and EnableClientJsonOmitzeroTag to false
+//   - options that were already set are left unchanged
+func (c *GenerateConfig) applyDefaults() {
+	if c.StructFieldsAlwaysPointers == nil {
+		c.StructFieldsAlwaysPointers = boolPointer(true)
+	}
+
+	if c.InlineFragmentAlwaysPointers == nil {
+		c.InlineFragmentAlwaysPointers = boolPointer(false)
+	}
+
+	if c.EnableClientJsonOmitemptyTag == nil {
+		c.EnableClientJsonOmitemptyTag = boolPointer(true)
+	}
+
+	if c.EnableClientJsonOmitzeroTag == nil {
+		c.EnableClientJsonOmitzeroTag = boolPointer(false)
+	}
+}
+
+// boolPointer returns a pointer to b.
+//
+// Arguments:
+//   - b: the value
+//
+// Returns:
+//   - *bool: a pointer to a copy of b
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - none
+func boolPointer(b bool) *bool {
+	return &b
+}
+
 type NamingConfig struct {
 	Query    string `yaml:"query,omitempty"`
 	Mutation string `yaml:"mutation,omitempty"`

--- a/internal/fileglob/fileglob.go
+++ b/internal/fileglob/fileglob.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2020 gqlgen authors
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// Package fileglob expands the file patterns accepted by the schema and query
+// settings. It is a copy of the glob handling in gqlgen's config loading,
+// which gqlgen does not export.
+package fileglob
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+var path2regex = strings.NewReplacer(
+	`.`, `\.`,
+	`*`, `.+`,
+	`\`, `[\\/]`,
+	`/`, `[\\/]`,
+)
+
+// Expand resolves file patterns into the files they match.
+//
+// Arguments:
+//   - patterns: file paths or glob patterns; a pattern containing "**" matches any number of directories
+//
+// Returns:
+//   - []string: the matched paths in pattern order, each path listed once
+//   - error: non-nil if a pattern is malformed or a directory walk fails
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - a pattern that matches nothing contributes no paths and no error
+func Expand(patterns []string) ([]string, error) {
+	var files []string
+
+	for _, pattern := range patterns {
+		matches, err := expand(pattern)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, match := range matches {
+			if !slices.Contains(files, match) {
+				files = append(files, match)
+			}
+		}
+	}
+
+	return files, nil
+}
+
+// expand resolves one pattern.
+//
+// Arguments:
+//   - pattern: a file path or glob pattern
+//
+// Returns:
+//   - []string: the matched paths
+//   - error: non-nil if the pattern is malformed or a directory walk fails
+//
+// Preconditions:
+//   - none
+//
+// Postconditions:
+//   - none
+func expand(pattern string) ([]string, error) {
+	// for ** we want to override default globbing patterns and walk all
+	// subdirectories to match schema files.
+	if !strings.Contains(pattern, "**") {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob schema filename %s: %w", pattern, err)
+		}
+
+		return matches, nil
+	}
+
+	pathParts := strings.SplitN(pattern, "**", 2)
+	rest := strings.TrimPrefix(strings.TrimPrefix(pathParts[1], `\`), `/`)
+	// turn the rest of the glob into a regex, anchored only at the end because ** allows
+	// for any number of dirs in between and walk will let us match against the full path name
+	globRe := regexp.MustCompile(path2regex.Replace(rest) + `$`)
+
+	var matches []string
+
+	err := filepath.Walk(pathParts[0], func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if globRe.MatchString(strings.TrimPrefix(path, pathParts[0])) {
+			matches = append(matches, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
+	}
+
+	return matches, nil
+}

--- a/parsequery/parse_test.go
+++ b/parsequery/parse_test.go
@@ -1,0 +1,81 @@
+package parsequery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestParseQueryDocuments(t *testing.T) {
+	t.Parallel()
+
+	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "schema.graphql", Input: `
+type Query {
+	user(id: ID!): User
+}
+
+type User {
+	id: ID!
+	name: String!
+}
+`})
+
+	tests := []struct {
+		name           string
+		sources        []*ast.Source
+		wantOperations []string
+		wantFragments  []string
+		wantErr        string
+	}{
+		{
+			name: "operations and fragments from several sources are merged",
+			sources: []*ast.Source{
+				{Name: "user.graphql", Input: `query GetUser($id: ID!) { user(id: $id) { ...UserFields } }`},
+				{Name: "fragments.graphql", Input: `fragment UserFields on User { id name }`},
+			},
+			wantOperations: []string{"GetUser"},
+			wantFragments:  []string{"UserFields"},
+		},
+		{
+			name:    "syntax error is reported",
+			sources: []*ast.Source{{Name: "broken.graphql", Input: `query GetUser { user(id: `}},
+			wantErr: "broken.graphql",
+		},
+		{
+			name:    "unknown field fails validation",
+			sources: []*ast.Source{{Name: "bad.graphql", Input: `query GetUser { user(id: "1") { email } }`}},
+			wantErr: "email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc, err := ParseQueryDocuments(schema, tt.sources)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			operations := make([]string, 0, len(doc.Operations))
+			for _, operation := range doc.Operations {
+				operations = append(operations, operation.Name)
+			}
+
+			fragments := make([]string, 0, len(doc.Fragments))
+			for _, fragment := range doc.Fragments {
+				fragments = append(fragments, fragment.Name)
+			}
+
+			require.Equal(t, tt.wantOperations, operations)
+			require.Equal(t, tt.wantFragments, fragments)
+		})
+	}
+}

--- a/parsequery/query_source.go
+++ b/parsequery/query_source.go
@@ -26,70 +26,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 
-	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/gqlgo/gqlgenc/internal/fileglob"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-var path2regex = strings.NewReplacer(
-	`.`, `\.`,
-	`*`, `.+`,
-	`\`, `[\\/]`,
-	`/`, `[\\/]`,
-)
-
 // LoadQuerySources loads query sources from file names.
-// This is a modified copy of gqlgen's LoadConfig schema loading implementation.
-// Supports glob patterns like **/test/*.graphql.
+// Supports glob patterns like **/test/*.graphql; see internal/fileglob.
 func LoadQuerySources(queryFileNames []string) ([]*ast.Source, error) {
-	var noGlobQueryFileNames config.StringList
-
-	var err error
-
-	preGlobbing := queryFileNames
-	for _, f := range preGlobbing {
-		var matches []string
-
-		// for ** we want to override default globbing patterns and walk all
-		// subdirectories to match schema files.
-		if strings.Contains(f, "**") {
-			pathParts := strings.SplitN(f, "**", 2)
-			rest := strings.TrimPrefix(strings.TrimPrefix(pathParts[1], `\`), `/`)
-			// turn the rest of the glob into a regex, anchored only at the end because ** allows
-			// for any number of dirs in between and walk will let us match against the full path name
-			globRe := regexp.MustCompile(path2regex.Replace(rest) + `$`)
-
-			err := filepath.Walk(pathParts[0], func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if globRe.MatchString(strings.TrimPrefix(path, pathParts[0])) {
-					matches = append(matches, path)
-				}
-
-				return nil
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
-			}
-		} else {
-			matches, err = filepath.Glob(f)
-			if err != nil {
-				return nil, fmt.Errorf("failed to glob schema filename %v: %w", f, err)
-			}
-		}
-
-		for _, m := range matches {
-			if noGlobQueryFileNames.Has(m) {
-				continue
-			}
-
-			noGlobQueryFileNames = append(noGlobQueryFileNames, m)
-		}
+	noGlobQueryFileNames, err := fileglob.Expand(queryFileNames)
+	if err != nil {
+		return nil, err
 	}
 
 	querySources := make([]*ast.Source, 0, len(noGlobQueryFileNames))

--- a/parsequery/query_source_test.go
+++ b/parsequery/query_source_test.go
@@ -1,0 +1,91 @@
+package parsequery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func TestLoadQuerySources(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.graphql"), "query A { a }")
+	writeFile(t, filepath.Join(dir, "b.graphql"), "query B { b }")
+	writeFile(t, filepath.Join(dir, "nested", "deep", "c.graphql"), "query C { c }")
+	writeFile(t, filepath.Join(dir, "nested", "ignored.txt"), "not graphql")
+
+	tests := []struct {
+		name      string
+		patterns  []string
+		wantNames []string
+		wantErr   string
+	}{
+		{
+			name:      "explicit file",
+			patterns:  []string{filepath.Join(dir, "a.graphql")},
+			wantNames: []string{"a.graphql"},
+		},
+		{
+			name:      "glob in one directory",
+			patterns:  []string{filepath.Join(dir, "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql"},
+		},
+		{
+			name:      "double star walks subdirectories",
+			patterns:  []string{filepath.Join(dir, "**", "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql", "nested/deep/c.graphql"},
+		},
+		{
+			name:      "the same file matched twice is loaded once",
+			patterns:  []string{filepath.Join(dir, "a.graphql"), filepath.Join(dir, "*.graphql")},
+			wantNames: []string{"a.graphql", "b.graphql"},
+		},
+		{
+			name:      "no match yields no sources",
+			patterns:  []string{filepath.Join(dir, "missing", "*.graphql")},
+			wantNames: []string{},
+		},
+		{
+			// filepath.Glob reports no match for a missing explicit path, so it is not an error today.
+			name:      "explicit missing file yields no sources",
+			patterns:  []string{filepath.Join(dir, "missing.graphql")},
+			wantNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sources, err := LoadQuerySources(tt.patterns)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(sources))
+			for _, source := range sources {
+				rel, err := filepath.Rel(dir, filepath.FromSlash(source.Name))
+				require.NoError(t, err)
+
+				names = append(names, filepath.ToSlash(rel))
+				require.NotEmpty(t, source.Input)
+			}
+
+			require.Equal(t, tt.wantNames, names)
+		})
+	}
+}


### PR DESCRIPTION
## Background

`config.LoadConfig` read the YAML file, validated the schema source, expanded globs, read the schema files, applied defaults, and assembled the gqlgen config in one 148-line function (cognitive complexity 39). The defaults were defined twice: once in the branch for a missing `generate:` section and once per unset option, and one of the locals was misnamed (`enableModelJsonOmitzeroTag` fed `EnableClientJsonOmitzeroTag`).

Stacked on #347 (and therefore #344); once those are merged this PR shows only the `LoadConfig` split.

## Changes

Pure refactor; the test suite is untouched.

- `LoadConfig` is now 40 lines that call, in order: `readConfig` (read, expand environment variables, decode with unknown fields rejected), `checkSchemaSource` (exactly one of `schema` and `endpoint`), `fileglob.Expand`, `readSchemaSources`, `GenerateConfig.applyDefaults`, and `newGQLConfig`.
- A missing `generate:` section is normalized to an empty `GenerateConfig` and then goes through the same `applyDefaults` as a partial one, so each default is defined once. The defaults themselves are unchanged: `structFieldsAlwaysPointers` true, `inlineFragmentAlwaysPointers` false, `enableClientJsonOmitemptyTag` true, `enableClientJsonOmitzeroTag` false.
- Error messages are unchanged, including the existing `config.exec` prefix on the client check, which is left for a separate fix.

## Testing

```console
$ go test -race -cover ./config/ ./generator/
ok  	github.com/gqlgo/gqlgenc/config	coverage: 68.6% of statements
ok  	github.com/gqlgo/gqlgenc/generator	coverage: 72.3% of statements
$ golangci-lint run ./...   # v2.13.2
0 issues.
```

The golden tests in `generator` pass unchanged and regenerating the seven local-schema examples produces no diff. The workflow was also run locally with `act` and the Build job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXeckxerPDue8RsFThpj7f
